### PR TITLE
0.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile:1
 
-FROM node:20.19.3-bookworm-slim as base
+FROM node:20.19.5-bookworm-slim as base
 ARG PY_VERSION="3.11.0"
 
 # setting the enviroment 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ There are a lot of projects in GitHub trying to scrape the supermarket data, but
 You only need to run the following code to get all the data currently shared by the supermarkets.
 
 ```python
-from il_supermarket_scarper import MainScrapperRunner
+from il_supermarket_scarper import ScarpingTask
 
-scraper = MainScrapperRunner()
-scraper.run()
+scraper = ScarpingTask()
+scraper.start()
 ```
 
 
@@ -67,7 +67,7 @@ Quick start
 
 il_supermarket_scarper can be installed using pip:
 
-    python3 pip install israeli-supermarket-scraper
+    python3 pip install il-supermarket-scraper
 
 If you want to run the latest version of the code, you can install it from the
 repo directly:

--- a/il_supermarket_scarper/engines/cerberus.py
+++ b/il_supermarket_scarper/engines/cerberus.py
@@ -66,7 +66,7 @@ class Cerberus(Engine):
             )
             return results
         except Exception as e:  # pylint: disable=broad-except
-            self.on_download_fail(e, files=files)
+            self.on_download_fail(e, file_names=files)
             raise e
 
     def get_type_pattern(self, files_types):

--- a/il_supermarket_scarper/scrappers/doralon.py
+++ b/il_supermarket_scarper/scrappers/doralon.py
@@ -9,6 +9,6 @@ class DorAlon(Cerberus):
         super().__init__(
             folder_name=folder_name,
             chain=DumpFolderNames.DOR_ALON,
-            chain_id="7290492000005",
+            chain_id=["7290492000005","729049000005"],
             ftp_username="doralon",
         )

--- a/il_supermarket_scarper/scrappers/tests/test_all.py
+++ b/il_supermarket_scarper/scrappers/tests/test_all.py
@@ -90,7 +90,7 @@ class OsheradTestCase(make_test_case(ScraperFactory.OSHER_AD, 1)):
     """Test case for ScraperFactory.OSHER_AD."""
 
 
-class PolizerTestCase(make_test_case(ScraperFactory.POLIZER, 1)):
+class PolizerTestCase(make_test_case(ScraperFactory.POLIZER, 2)):
     """Test case for ScraperFactory.POLIZER."""
 
 
@@ -102,7 +102,7 @@ class SalachDabachTestCase(make_test_case(ScraperFactory.SALACH_DABACH, 4)):
     """Test case for ScraperFactory.SALACH_DABACH."""
 
 
-class ShefaBarcartAshemTestCase(make_test_case(ScraperFactory.SHEFA_BARCART_ASHEM, 41)):
+class ShefaBarcartAshemTestCase(make_test_case(ScraperFactory.SHEFA_BARCART_ASHEM, 42)):
     """Test case for ScraperFactory.SHEFA_BARCART_ASHEM."""
 
 

--- a/il_supermarket_scarper/utils/scraper_status.py
+++ b/il_supermarket_scarper/utils/scraper_status.py
@@ -120,15 +120,15 @@ class ScraperStatus:
         )
 
     @lock_by_string()
-    def on_download_fail(self, execption, **additional_info):
+    def on_download_fail(self, execption, download_urls=None, file_names=None):
         """report when the scraping in failed"""
         self._insert_an_update(
             ScraperStatus.FAILED,
             execption=str(execption),
             traceback=traceback.format_exc(),
-            **additional_info,
+            download_urls=download_urls if download_urls else [],
+            file_names=file_names if file_names else [],
         )
-
     def _insert_an_update(self, status, **additional_info):
         """Insert an update into the MongoDB collection."""
         document = {

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     tests_require=dev_required,
     extras_require={"test": ["pytest", "pytest-xdist"]},
     # *strongly* suggested for sharing
-    version="0.6.1",
+    version="0.6.2",
     # The license can be anything you like
     license="MIT",
     description="python package that implement a scraping for israeli supermarket data",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improve failure reporting and DorAlon IDs, update tests/docs, bump Docker base image, and release 0.6.2.
> 
> - **Engine/Status**:
>   - `Cerberus._scrape`: route failures to `on_download_fail(e, file_names=files)`.
>   - `ScraperStatus.on_download_fail`: new signature (`download_urls=None, file_names=None`) and explicit fields in stored document.
> - **Scraper Config**:
>   - `DorAlon`: `chain_id` now supports multiple IDs `['7290492000005','729049000005']`.
> - **Tests**:
>   - Update expected counts: `POLIZER` to `2`, `SHEFA_BARCART_ASHEM` to `42`.
> - **Docs**:
>   - `README.md`: update usage to `ScarpingTask.start()` and pip package name to `il-supermarket-scraper`.
> - **Build**:
>   - `Dockerfile`: bump Node base image to `20.19.5-bookworm-slim`.
> - **Release**:
>   - `setup.py`: version bump to `0.6.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a643ace915876d65a9f07c51a4a5ada076f7001. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->