### PR TITLE
Refactor file handling to use in-memory buffers instead of temporary files

### DIFF
--- a/il_supermarket_scarper/engines/bina.py
+++ b/il_supermarket_scarper/engines/bina.py
@@ -125,7 +125,18 @@ class Bina(Aspx):
         return None
 
     @url_connection_retry()
-    def retrieve_file(self, file_link, file_save_path, timeout=30):
+    def retrieve_file_to_stream(self, file_link, timeout=30):
+        response_content = self.session_with_cookies_by_chain(
+            file_link,
+            timeout=timeout
+        )
+        spath = json.loads(response_content.content)
+        Logger.debug(f"Found spath: {spath}")
+
+        url = spath[0]["SPath"]
+        return url_retrieve(url, timeout=timeout)
+
+    def _wget_file(self, file_link):
         response_content = self.session_with_cookies_by_chain(
             file_link,
         )
@@ -133,18 +144,4 @@ class Bina(Aspx):
         Logger.debug(f"Found spath: {spath}")
 
         url = spath[0]["SPath"]
-        ext = file_link.split(".")[-1]
-
-        url_retrieve(url, file_save_path + "." + ext, timeout=timeout)
-        return file_save_path + "." + ext
-
-    def _wget_file(self, file_link, file_save_path):
-        response_content = self.session_with_cookies_by_chain(
-            file_link,
-        )
-        spath = json.loads(response_content.content)
-        Logger.debug(f"Found spath: {spath}")
-
-        url = spath[0]["SPath"]
-        ext = file_link.split(".")[-1]
-        return super()._wget_file(url, file_save_path.split(".")[0] + "." + ext)
+        return super()._wget_file(url)

--- a/il_supermarket_scarper/engines/cerberus.py
+++ b/il_supermarket_scarper/engines/cerberus.py
@@ -2,11 +2,11 @@ import os
 import datetime
 
 from il_supermarket_scarper.utils import (
-    extract_xml_file_from_gz_file,
+    extract_xml_file_from_gz,
     Logger,
     execute_in_parallel,
     collect_from_ftp,
-    fetch_temporary_gz_file_from_ftp,
+    fetch_ftp_to_buffer,
     FileTypesFilters,
 )
 from .engine import Engine
@@ -192,7 +192,7 @@ class Cerberus(Engine):
     def persist_from_ftp(self, file_name):
         """download file to hard drive and extract it."""
         downloaded = False
-        extract_succefully = False
+        extract_successfully = False
         restart_and_retry = False
         error = None
         try:
@@ -201,42 +201,37 @@ class Cerberus(Engine):
                 raise ValueError(f"File {file_name} extension is not .gz or .xml")
 
             Logger.debug(f"Start persisting file {file_name}")
-            temporary_gz_file_path = os.path.join(self.storage_path, file_name)
-
-            fetch_temporary_gz_file_from_ftp(
+            
+            buffer = fetch_ftp_to_buffer(
                 self.ftp_host,
                 self.ftp_username,
                 self.ftp_password,
                 self.ftp_path,
-                temporary_gz_file_path,
+                file_name,
                 timeout=30,
             )
             downloaded = True
-
+            Logger.debug(f"File size is {buffer.getbuffer().nbytes} bytes.")
+            
             if ext == ".gz":
-                Logger.debug(
-                    f"File size is {os.path.getsize(temporary_gz_file_path)} bytes."
-                )
-                extract_xml_file_from_gz_file(temporary_gz_file_path)
-
+                buffer = extract_xml_file_from_gz(buffer, file_name)
+            
+            file_save_path = os.path.join(self.storage_path, file_name)
+            with open(file_save_path, 'wb') as f:
+                f.write(buffer.getvalue())
+        
             Logger.debug(f"Done persisting file {file_name}")
-            extract_succefully = True
+            extract_successfully = True
         except Exception as exception:  # pylint: disable=broad-except
-            Logger.error(
-                f"Error downloading {file_name},extract_succefully={extract_succefully}"
-                f",downloaded={downloaded}"
-            )
+            self._log_download_error(file_name, extract_successfully, downloaded)
             Logger.error_execption(exception)
             error = str(exception)
             restart_and_retry = True
-        finally:
-            if ext == ".gz" and os.path.exists(temporary_gz_file_path):
-                os.remove(temporary_gz_file_path)
 
         return {
             "file_name": file_name,
             "downloaded": downloaded,
-            "extract_succefully": extract_succefully,
+            "extract_successfully": extract_successfully,
             "restart_and_retry": restart_and_retry,
             "error": error,
         }

--- a/il_supermarket_scarper/engines/cerberus.py
+++ b/il_supermarket_scarper/engines/cerberus.py
@@ -201,7 +201,7 @@ class Cerberus(Engine):
                 raise ValueError(f"File {file_name} extension is not .gz or .xml")
 
             Logger.debug(f"Start persisting file {file_name}")
-            
+
             buffer = fetch_ftp_to_buffer(
                 self.ftp_host,
                 self.ftp_username,
@@ -212,19 +212,19 @@ class Cerberus(Engine):
             )
             downloaded = True
             Logger.debug(f"File size is {buffer.getbuffer().nbytes} bytes.")
-            
+
             if ext == ".gz":
                 buffer = extract_xml_file_from_gz(buffer, file_name)
-            
+
             file_save_path = os.path.join(self.storage_path, file_name)
             with open(file_save_path, 'wb') as f:
                 f.write(buffer.getvalue())
-        
+
             Logger.debug(f"Done persisting file {file_name}")
             extract_successfully = True
         except Exception as exception:  # pylint: disable=broad-except
             self._log_download_error(file_name, extract_successfully, downloaded)
-            Logger.error_execption(exception)
+            Logger.error_exception(exception)
             error = str(exception)
             restart_and_retry = True
 

--- a/il_supermarket_scarper/engines/engine.py
+++ b/il_supermarket_scarper/engines/engine.py
@@ -4,13 +4,14 @@ import re
 import random
 import uuid
 import datetime
+from pathlib import Path
 
 from il_supermarket_scarper.utils import (
     get_output_folder,
     FileTypesFilters,
     Logger,
     ScraperStatus,
-    extract_xml_file_from_gz_file,
+    extract_xml_file_from_gz,
     url_connection_retry,
     session_with_cookies,
     url_retrieve,
@@ -38,7 +39,7 @@ class Engine(ScraperStatus, ABC):
         self.assigned_cookie = f"{self.chain.name}_{uuid.uuid4()}_cookies.txt"
 
     def get_storage_path(self):
-        """the the storage page of the files downloaded"""
+        """the storage page of the files downloaded"""
         return self.storage_path
 
     def is_valid_file_empty(self, file_name):
@@ -447,10 +448,10 @@ class Engine(ScraperStatus, ABC):
         return filtered_names, filtered_urls, filtered_sizes
 
     @url_connection_retry()
-    def retrieve_file(self, file_link, file_save_path, timeout=30):
-        """download file"""
-        url_retrieve(file_link, file_save_path, timeout=timeout)
-        return file_save_path
+    def retrieve_file_to_stream(self, file_link, timeout=30):
+        """download file to stream"""
+        return url_retrieve(file_link, timeout=timeout)
+
 
     def save_and_extract(self, arg):
         """download file and extract it"""
@@ -460,7 +461,7 @@ class Engine(ScraperStatus, ABC):
         Logger.debug(f"Downloading {file_link} to {file_save_path}")
         (
             downloaded,
-            extract_succefully,
+            extract_successfully,
             error,
             restart_and_retry,
         ) = self._save_and_extract(file_link, file_save_path)
@@ -468,61 +469,65 @@ class Engine(ScraperStatus, ABC):
         return {
             "file_name": file_name,
             "downloaded": downloaded,
-            "extract_succefully": extract_succefully,
+            "extract_successfully": extract_successfully,
             "error": error,
             "restart_and_retry": restart_and_retry,
         }
 
-    def _wget_file(self, file_link, file_save_path):
-        return wget_file(file_link, file_save_path)
+    def _wget_file(self, file_link):
+        return wget_file(file_link)
+    
+    def _fix_extension(self, file_link, file_save_path):
+        """add appropriate extension if missing from file"""
+        extenstions = (".gz", ".xml")
+        if file_link.endswith(extenstions) and not file_save_path.endswith(extenstions):
+            file_save_path += Path(file_link.split("?")[0]).suffix
+        return file_save_path
 
     def _save_and_extract(self, file_link, file_save_path):
         downloaded = False
-        extract_succefully = False
+        extract_successfully = False
         error = None
         restart_and_retry = False
         try:
-
-            # add ext if possible
-            if not (
-                file_save_path.endswith(".gz") or file_save_path.endswith(".xml")
-            ) and (file_link.endswith(".gz") or file_link.endswith(".xml")):
-                file_save_path = (
-                    file_save_path + "." + file_link.split("?")[0].split(".")[-1]
-                )
-
-            # try to download the file
+            file_save_path = self._fix_extension(file_link, file_save_path)
+            
+            # Try stream download first
             try:
-                file_save_path_with_ext = self.retrieve_file(file_link, file_save_path)
+                buffer = self.retrieve_file_to_stream(file_link)
             except Exception as e:  # pylint: disable=broad-except
                 Logger.warning(f"Error downloading {file_link}: {e}")
-                file_save_path_with_ext = self._wget_file(file_link, file_save_path)
+                buffer = self._wget_file(file_link)
+            
+            Logger.debug(f"File size is {buffer.getbuffer().nbytes} bytes.")
             downloaded = True
 
-            if file_save_path_with_ext.endswith("gz"):
-                Logger.debug(
-                    f"File size is {os.path.getsize(file_save_path_with_ext)} bytes."
-                )
-                extract_xml_file_from_gz_file(file_save_path_with_ext)
+            if file_link.endswith(".gz"):
+                buffer = extract_xml_file_from_gz(buffer, file_save_path)
+                file_save_path = Path(file_save_path).with_suffix('.xml')
 
-                os.remove(file_save_path_with_ext)
-            extract_succefully = True
+            
+            with open(file_save_path, 'wb') as f:
+                f.write(buffer.getvalue())
 
+            extract_successfully = True
             Logger.debug(f"Done downloading {file_link}")
+            
         except RestartSessionError as exception:
-            Logger.error(
-                f"Error downloading {file_link},extract_succefully={extract_succefully}"
-                f",downloaded={downloaded}"
-            )
-            Logger.error_execption(exception)
+            self._log_download_error(file_link, extract_successfully, downloaded)
+            Logger.error_exception(exception)
             error = str(exception)
             restart_and_retry = True
+            
         except Exception as exception:  # pylint: disable=broad-except
-            Logger.error(
-                f"Error downloading {file_link},extract_succefully={extract_succefully}"
-                f",downloaded={downloaded}"
-            )
-            Logger.error_execption(exception)
+            self._log_download_error(file_link, extract_successfully, downloaded)
+            Logger.error_exception(exception)
             error = str(exception)
 
-        return downloaded, extract_succefully, error, restart_and_retry
+        return downloaded, extract_successfully, error, restart_and_retry
+        
+    def _log_download_error(file_link, extract_successfully, downloaded):
+        Logger.error(
+                f"Error downloading {file_link},extract_successfully={extract_successfully}, "
+                f"downloaded={downloaded}"
+            )

--- a/il_supermarket_scarper/engines/engine.py
+++ b/il_supermarket_scarper/engines/engine.py
@@ -476,7 +476,7 @@ class Engine(ScraperStatus, ABC):
 
     def _wget_file(self, file_link):
         return wget_file(file_link)
-    
+
     def _fix_extension(self, file_link, file_save_path):
         """add appropriate extension if missing from file"""
         extenstions = (".gz", ".xml")
@@ -491,14 +491,14 @@ class Engine(ScraperStatus, ABC):
         restart_and_retry = False
         try:
             file_save_path = self._fix_extension(file_link, file_save_path)
-            
+
             # Try stream download first
             try:
                 buffer = self.retrieve_file_to_stream(file_link)
             except Exception as e:  # pylint: disable=broad-except
                 Logger.warning(f"Error downloading {file_link}: {e}")
                 buffer = self._wget_file(file_link)
-            
+
             Logger.debug(f"File size is {buffer.getbuffer().nbytes} bytes.")
             downloaded = True
 
@@ -506,27 +506,27 @@ class Engine(ScraperStatus, ABC):
                 buffer = extract_xml_file_from_gz(buffer, file_save_path)
                 file_save_path = Path(file_save_path).with_suffix('.xml')
 
-            
+
             with open(file_save_path, 'wb') as f:
                 f.write(buffer.getvalue())
 
             extract_successfully = True
             Logger.debug(f"Done downloading {file_link}")
-            
+
         except RestartSessionError as exception:
             self._log_download_error(file_link, extract_successfully, downloaded)
             Logger.error_exception(exception)
             error = str(exception)
             restart_and_retry = True
-            
+
         except Exception as exception:  # pylint: disable=broad-except
             self._log_download_error(file_link, extract_successfully, downloaded)
             Logger.error_exception(exception)
             error = str(exception)
 
         return downloaded, extract_successfully, error, restart_and_retry
-        
-    def _log_download_error(file_link, extract_successfully, downloaded):
+
+    def _log_download_error(self, file_link, extract_successfully, downloaded):
         Logger.error(
                 f"Error downloading {file_link},extract_successfully={extract_successfully}, "
                 f"downloaded={downloaded}"

--- a/il_supermarket_scarper/scrapper_runner.py
+++ b/il_supermarket_scarper/scrapper_runner.py
@@ -28,12 +28,10 @@ class MainScrapperRunner:
         else:
             self.size_estimation_mode = size_estimation_mode
         Logger.info(f"size_estimation_mode: {self.size_estimation_mode}")
-
-        if not enabled_scrapers:
-            enabled_scrapers = ScraperFactory.all_scrapers_name()
-
-        self.enabled_scrapers = enabled_scrapers
+        
+        self.enabled_scrapers = enabled_scrapers or ScraperFactory.all_scrapers_name()
         Logger.info(f"Enabled scrapers: {self.enabled_scrapers}")
+        
         self.dump_folder_name = dump_folder_name
         self.multiprocessing = multiprocessing
         self.lookup_in_db = lookup_in_db

--- a/il_supermarket_scarper/scrappers/super_pharm.py
+++ b/il_supermarket_scarper/scrappers/super_pharm.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import urllib.parse
 import datetime
+from io import BytesIO
 
 import json
 from il_supermarket_scarper.engines import MultiPageWeb
@@ -37,7 +38,7 @@ class SuperPharm(MultiPageWeb):
         return links, filenames, file_sizes
 
     @url_connection_retry()
-    def retrieve_file(self, file_link, file_save_path, timeout=15):
+    def retrieve_file_to_stream(self, file_link, timeout=15):
         Logger.debug(f"On a new Session: calling {file_link}")
 
         response_content = self.session_with_cookies_by_chain(
@@ -49,10 +50,10 @@ class SuperPharm(MultiPageWeb):
         file_to_save = self.session_with_cookies_by_chain(
             self.url + spath["href"], timeout=timeout
         )
-        file_to_save_with_ext = file_save_path + ".gz"
-        Path(file_to_save_with_ext).write_bytes(file_to_save.content)
+        buffer = BytesIO(file_to_save.content)
+        buffer.seek(0)
 
-        return file_to_save_with_ext
+        return buffer
 
     def get_file_types_id(self, files_types=None):
         """get the file type id"""

--- a/il_supermarket_scarper/utils/__init__.py
+++ b/il_supermarket_scarper/utils/__init__.py
@@ -1,4 +1,4 @@
-from .gzip_utils import extract_xml_file_from_gz_file
+from .gzip_utils import extract_xml_file_from_gz
 from .logger import Logger
 from .status import (
     get_output_folder,
@@ -21,7 +21,7 @@ from .connection import (
     session_with_cookies,
     url_retrieve,
     collect_from_ftp,
-    fetch_temporary_gz_file_from_ftp,
+    fetch_ftp_to_buffer,
     wget_file,
 )
 from .loop import execute_in_parallel, multiple_page_aggregtion

--- a/il_supermarket_scarper/utils/connection.py
+++ b/il_supermarket_scarper/utils/connection.py
@@ -13,6 +13,7 @@ from http.cookiejar import LoadError
 from typing import Union, List
 from urllib.error import URLError
 from urllib3.exceptions import MaxRetryError, ReadTimeoutError
+from io import BytesIO
 
 
 import requests
@@ -355,12 +356,14 @@ def get_from_webpage(cached_page, extraction_type):
     return content
 
 
-def url_retrieve(url, filename, timeout=30):
+def url_retrieve(url, timeout=30, chunk_size=8192):
     # from urllib.request import urlretrieve
     # urlretrieve(url, filename)
     # >>> add here timeout if needed
     """alternative to urllib.request.urlretrieve"""
     # https://gist.github.com/xflr6/f29ed682f23fd27b6a0b1241f244e6c9
+    buffer = BytesIO()
+    
     with contextlib.closing(
         requests.get(
             url, stream=True, timeout=timeout, headers={"Accept-Encoding": None}
@@ -369,16 +372,18 @@ def url_retrieve(url, filename, timeout=30):
         _request.raise_for_status()
         size = int(_request.headers.get("Content-Length", "-1"))
         read = 0
-        with open(filename, "wb") as file:
-            for chunk in _request.iter_content(chunk_size=None):
-                time.sleep(0.5)
-                read += len(chunk)
-                file.write(chunk)
-                file.flush()
+                
+        for chunk in _request.iter_content(chunk_size=chunk_size):
+            # time.sleep(0.5) why is it here???
+            read += len(chunk)
+            buffer.write(chunk)
 
     if size >= 0 and read < size:
         msg = f"retrieval incomplete: got only {read:d} out of {size:d} bytes"
-        raise ValueError(msg, (filename, _request.headers))
+        raise ValueError(msg)
+    
+    buffer.seek(0)
+    return buffer
 
 
 @url_connection_retry(60 * 5)
@@ -414,49 +419,42 @@ def collect_from_ftp(
 
 
 @download_connection_retry()
-def fetch_temporary_gz_file_from_ftp(
-    ftp_host, ftp_username, ftp_password, ftp_path, temporary_gz_file_path, timeout=15
+def fetch_ftp_to_buffer(
+    ftp_host, ftp_username, ftp_password, ftp_path, file_name, timeout=15, chunk_size=8192
 ):
-    """download a file from a cerberus base site."""
-    with open(temporary_gz_file_path, "wb") as file_ftp:
-        file_name = ntpath.basename(temporary_gz_file_path)
-        ftp = FTP_TLS(ftp_host, ftp_username, ftp_password, timeout=timeout)
-        ftp.trust_server_pasv_ipv4_address = True
-        ftp.cwd(ftp_path)
-        ftp.retrbinary("RETR " + file_name, file_ftp.write)
-        ftp.quit()
+    """download a file to stream from a cerberus base site."""
+    buffer = BytesIO()
+
+    ftp = FTP_TLS(ftp_host, ftp_username, ftp_password, timeout=timeout)
+    ftp.trust_server_pasv_ipv4_address = True
+    ftp.cwd(ftp_path)
+    ftp.retrbinary("RETR " + file_name, buffer.write, blocksize=chunk_size)
+    ftp.quit()
+    
+    buffer.seek(0)
+    return buffer
 
 
-def wget_file(file_link, file_save_path):
-    """use wget to download file"""
-    Logger.debug(f"trying wget file {file_link} to {file_save_path}.")
+def wget_file(file_link):
+    """use wget to download file into buffer"""
+    Logger.debug(f"trying wget file {file_link}.")
 
     with subprocess.Popen(
-        f"wget --output-document={file_save_path} '{file_link}'",
+        f"wget --output-document=- '{file_link}'",
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        text=True,
         shell=True,
     ) as process:
         std_out, std_err = process.communicate()
-    Logger.debug(f"Wget stdout {std_out}")
-    Logger.debug(f"Wget stderr {std_err}")
+    
+    std_err_text = std_err.decode('utf-8', errors='ignore')
+    Logger.debug(f"Wget stderr {std_err_text}")
 
-    if not os.path.exists(file_save_path):
-        Logger.error(f"fils is not exists after wget {file_save_path}")
-        raise FileNotFoundError(
-            f"File wasn't downloaded with wget,std_err is {std_err}"
-        )
-
-    # wget will create file always, so we need to check if there was an error
-    # example for validate case is collecting start and
-    # the file is removed before downloading (change of hour)
-    if "ERROR 403" in std_err or "ERROR 404" in std_err:
-        if os.path.exists(file_save_path):
-            os.remove(file_save_path)
-        Logger.error(f"Got error {std_err} while downloading {file_link}")
-        raise FileNotFoundError(
-            f"File wan't found in the remote, possibly removed between "
-            f"collection and download, std_err is {std_err}"
-        )
-    return file_save_path
+    if process.returncode != 0:
+            Logger.error(f"wget failed with return code {process.returncode}")
+            raise FileNotFoundError(
+                f"File download failed, stderr: {std_err_text}"
+            )
+    buffer = BytesIO(std_out)
+    buffer.seek(0)
+    return buffer

--- a/il_supermarket_scarper/utils/gzip_utils.py
+++ b/il_supermarket_scarper/utils/gzip_utils.py
@@ -5,58 +5,52 @@ import io
 import zipfile
 from .exceptions import RestartSessionError
 
+GZIP_MAGIC_BYTES = b'\x1f\x8b'
+ZIP_MAGIC_BYTES = b'PK'
 
-def extract_xml_file_from_gz_file(file_save_path):
-    """extract xml from gz"""
-    target_file_name = os.path.splitext(file_save_path)[0] + ".xml"
+def extract_xml_file_from_gz(source_buffer, file_name):
+    """Extract xml from gz file or stream"""
+    source_buffer.seek(0)
+    magic_bytes = source_buffer.read(2)
+    source_buffer.seek(0)
+    
+    output_buffer = io.BytesIO()
+  
     try:
-        with gzip.open(file_save_path, "rb") as infile:
-            with open(target_file_name, "wb") as outfile:
-                shutil.copyfileobj(infile, outfile)
-    except (gzip.BadGzipFile, EOFError) as exception:
-        try:
-            with open(file_save_path, "rb") as response_content:
-                with zipfile.ZipFile(io.BytesIO(response_content.read())) as the_zip:
-                    zip_info = the_zip.infolist()[0]
-                    with the_zip.open(zip_info) as the_file:
-                        with open(target_file_name, "wb") as f_out:
-                            f_out.write(the_file.read())
-
-        except (  # pylint: disable=broad-except,redefined-outer-name
-            Exception
-        ) as exception:
-            report_failed_zip(exception, file_save_path, target_file_name)
+        if magic_bytes == GZIP_MAGIC_BYTES:
+            with gzip.open(source_buffer, "rb") as infile:
+                shutil.copyfileobj(infile, output_buffer)
+                
+        elif magic_bytes == ZIP_MAGIC_BYTES:
+            with zipfile.ZipFile(source_buffer) as the_zip:
+                with the_zip.open(the_zip.infolist()[0]) as the_file:
+                    shutil.copyfileobj(the_file, output_buffer)
+        else:
+            raise ValueError(f"Unknown compression format. Magic bytes: {magic_bytes.hex()}")
 
     except Exception as exception:  # pylint: disable=broad-except
-        report_failed_zip(exception, file_save_path, target_file_name)
+        report_failed_zip(exception, source_buffer, file_name)
+    
+    output_buffer.seek(0)
+    return output_buffer
 
-
-def report_failed_zip(exception, file_save_path, target_file_name):
-    """report a file wasn't able to extracted"""
-
+def report_failed_zip(exception, source_buffer, file_name):
+    """Report a file wasn't able to be extracted"""
     try:
-        file_size = os.path.getsize(file_save_path)
-
-        file_contant = ""
-        with open(file_save_path, "r", encoding="utf-8") as file:
-            file_contant = file.readlines()
-
-        if "link expired" in str(file_contant):
+        source_buffer.seek(0)
+        content = source_buffer.read(1024).decode('utf-8', errors='ignore')  # Read first 1KB
+        
+        if "link expired" in content.lower():
             raise RestartSessionError()
-
+        
         raise ValueError(
-            f"Error decoding file:{file_save_path} with "
-            f"error: {str(exception)} file size {str(file_size)} ,"
-            f"trimed_file_contant {str(file_contant)[:100]}"
+            f"Error extracting file: {file_name} with error: {str(exception)}, "
+            f"buffer size: {source_buffer.getbuffer().nbytes} bytes, "
+            f"trimed_file_contant: {content[:100]}"
         )
     except UnicodeDecodeError:
         raise ValueError(
-            f"Error decoding file:{file_save_path} with "
-            f"error: {str(exception)} file size {str(file_size)} ,"
-            f"can't decode file"
+            f"Error extracting file: {file_name} with error: {str(exception)}, "
+            f"buffer size: {source_buffer.getbuffer().nbytes} bytes, "
+            f"can't decode content"
         )
-    finally:
-        os.remove(file_save_path)
-        # remove the corrupted file
-        if os.path.exists(target_file_name):
-            os.remove(target_file_name)

--- a/il_supermarket_scarper/utils/gzip_utils.py
+++ b/il_supermarket_scarper/utils/gzip_utils.py
@@ -1,6 +1,5 @@
 import gzip
 import shutil
-import os
 import io
 import zipfile
 from .exceptions import RestartSessionError
@@ -13,14 +12,14 @@ def extract_xml_file_from_gz(source_buffer, file_name):
     source_buffer.seek(0)
     magic_bytes = source_buffer.read(2)
     source_buffer.seek(0)
-    
+
     output_buffer = io.BytesIO()
-  
+
     try:
         if magic_bytes == GZIP_MAGIC_BYTES:
             with gzip.open(source_buffer, "rb") as infile:
                 shutil.copyfileobj(infile, output_buffer)
-                
+
         elif magic_bytes == ZIP_MAGIC_BYTES:
             with zipfile.ZipFile(source_buffer) as the_zip:
                 with the_zip.open(the_zip.infolist()[0]) as the_file:
@@ -30,7 +29,7 @@ def extract_xml_file_from_gz(source_buffer, file_name):
 
     except Exception as exception:  # pylint: disable=broad-except
         report_failed_zip(exception, source_buffer, file_name)
-    
+
     output_buffer.seek(0)
     return output_buffer
 
@@ -39,10 +38,10 @@ def report_failed_zip(exception, source_buffer, file_name):
     try:
         source_buffer.seek(0)
         content = source_buffer.read(1024).decode('utf-8', errors='ignore')  # Read first 1KB
-        
+
         if "link expired" in content.lower():
             raise RestartSessionError()
-        
+
         raise ValueError(
             f"Error extracting file: {file_name} with error: {str(exception)}, "
             f"buffer size: {source_buffer.getbuffer().nbytes} bytes, "

--- a/il_supermarket_scarper/utils/logger.py
+++ b/il_supermarket_scarper/utils/logger.py
@@ -70,7 +70,7 @@ class Logger:
             cls.logger.error(msg, *args, **kwargs)
 
     @classmethod
-    def error_execption(cls, _):
+    def error_exception(cls, _):
         """log execption"""
         if cls.enabled:
             cls.logger.error(

--- a/il_supermarket_scarper/utils/retry.py
+++ b/il_supermarket_scarper/utils/retry.py
@@ -83,7 +83,7 @@ def __retry_internal(  # pylint: disable=broad-except,too-many-locals
                     measured_seconds,
                     _delay,
                 )
-                logger.error_execption(error)
+                logger.error_exception(error)
 
             time.sleep(_delay)
             _delay *= backoff

--- a/il_supermarket_scarper/utils/scraper_status.py
+++ b/il_supermarket_scarper/utils/scraper_status.py
@@ -104,7 +104,7 @@ class ScraperStatus:
 
             documents = []
             for res in results:
-                if res["extract_succefully"]:
+                if res["extract_successfully"]:
                     documents.append(
                         {"file_name": res["file_name"], "when": when},
                     )

--- a/il_supermarket_scarper/utils/tests/test_gzip_utils.py
+++ b/il_supermarket_scarper/utils/tests/test_gzip_utils.py
@@ -1,7 +1,8 @@
 import os
 import pytest
+from io import BytesIO
 
-from il_supermarket_scarper.utils.gzip_utils import extract_xml_file_from_gz_file
+from il_supermarket_scarper.utils.gzip_utils import extract_xml_file_from_gz
 
 
 def test_unzip_bad_file():
@@ -10,13 +11,16 @@ def test_unzip_bad_file():
     file_path = (
         "il_supermarket_scarper/utils/tests/PriceFull7290876100000-003-202410070010.gz"
     )
+    file_name = "PriceFull7290876100000-003-202410070010.gz"
     file_content = None
     if os.path.exists(file_path):
         with open(file_path, "rb") as f:
             file_content = f.read()
+            
+        buffer = BytesIO(file_content)
 
     with pytest.raises(ValueError):
-        extract_xml_file_from_gz_file(file_path)
+        extract_xml_file_from_gz(buffer, file_name)
 
     if file_content is not None and not os.path.exists(file_path):
         with open(file_path, "wb") as f:

--- a/main.py
+++ b/main.py
@@ -11,32 +11,24 @@ def load_params():
     enabled_scrapers = os.getenv("ENABLED_SCRAPERS", None)
     if enabled_scrapers:
         enabled_scrapers = enabled_scrapers.split(",")
-
-        not_valid = list(
-            filter(
-                lambda scraper: scraper not in ScraperFactory.all_scrapers_name(),
-                enabled_scrapers,
-            )
-        )
+        valid_scrapers = ScraperFactory.all_scrapers_name()
+        not_valid = set(enabled_scrapers) - set(valid_scrapers)
+        
         if not_valid:
-            raise ValueError(f"ENABLED_SCRAPERS contains invalid {not_valid}")
+            raise ValueError(f"ENABLED_SCRAPERS contains invalid {list(not_valid)}")
 
         kwargs["enabled_scrapers"] = enabled_scrapers
 
     # validate file types
     enabled_file_types = os.getenv("ENABLED_FILE_TYPES", None)
     if enabled_file_types:
-
+        
         enabled_file_types = enabled_file_types.split(",")
-
-        not_valid = list(
-            filter(
-                lambda f_types: f_types not in FileTypesFilters.all_types(),
-                enabled_file_types,
-            )
-        )
+        valid_types = FileTypesFilters.all_types()
+        not_valid = set(enabled_file_types) - set(valid_types)
+        
         if not_valid:
-            raise ValueError(f"ENABLED_FILE_TYPES contains invalid {not_valid}")
+            raise ValueError(f"ENABLED_FILE_TYPES contains invalid {list(not_valid)}")
 
         kwargs["files_types"] = enabled_file_types
 

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ def load_params():
         enabled_scrapers = enabled_scrapers.split(",")
         valid_scrapers = ScraperFactory.all_scrapers_name()
         not_valid = set(enabled_scrapers) - set(valid_scrapers)
-        
+
         if not_valid:
             raise ValueError(f"ENABLED_SCRAPERS contains invalid {list(not_valid)}")
 
@@ -22,11 +22,11 @@ def load_params():
     # validate file types
     enabled_file_types = os.getenv("ENABLED_FILE_TYPES", None)
     if enabled_file_types:
-        
+
         enabled_file_types = enabled_file_types.split(",")
         valid_types = FileTypesFilters.all_types()
         not_valid = set(enabled_file_types) - set(valid_types)
-        
+
         if not_valid:
             raise ValueError(f"ENABLED_FILE_TYPES contains invalid {list(not_valid)}")
 

--- a/stress_test_results.json
+++ b/stress_test_results.json
@@ -9360,7 +9360,7 @@
                 "cumtime_per_call": "0.001"
             },
             {
-                "function": "/workspaces/israeli-supermarket-scarpers/il_supermarket_scarper/utils/logger.py:58(error_execption)",
+                "function": "/workspaces/israeli-supermarket-scarpers/il_supermarket_scarper/utils/logger.py:58(error_exception)",
                 "ncalls": "1",
                 "tottime": "0.000",
                 "tottime_per_call": "0.000",


### PR DESCRIPTION
use BytesIO buffers instead of writing temp files to disk. faster and cleaner.

url_retrieve(), fetch_ftp_to_buffer() and wget_file() in utils/connection.py now return a BytesIO buffer

extract_xml_file_from_gz() works with buffers directly and will not save the file (or change suffix to xml)
instead writing to file and xml suffix changes are delegated to engine.py

Removed all the temp file cleanup code

Also fixed the "extract_succefully" typo and cleaned up some of the validation logic