### PR TITLE
Replace pickle cookie storage with requests.Session

### DIFF
--- a/il_supermarket_scarper/engines/bina.py
+++ b/il_supermarket_scarper/engines/bina.py
@@ -123,7 +123,7 @@ class Bina(Aspx):
 
     async def _resolve_url(self, file_link):
         """Resolve the download URL from Bina's redirect response."""
-        response_content = await self.session_with_cookies_by_chain(file_link)
+        response_content = await self.request_with_session(file_link)
         spath = json.loads(response_content.content)
         Logger.debug(f"Found spath: {spath}")
         return spath[0]["SPath"]

--- a/il_supermarket_scarper/engines/bina.py
+++ b/il_supermarket_scarper/engines/bina.py
@@ -128,11 +128,11 @@ class Bina(Aspx):
         Logger.debug(f"Found spath: {spath}")
         return spath[0]["SPath"]
 
-    async def retrieve_file_to_memory(self, file_link, timeout=30):
+    async def download_file(self, file_link, timeout=30):
         """Retrieve file from Bina website directly to memory"""
         url = await self._resolve_url(file_link)
-        return await super().retrieve_file_to_memory(url, timeout=timeout)
+        return await super().download_file(url, timeout=timeout)
 
-    async def _wget_file_to_memory(self, file_link, timeout):
+    async def _download_file_via_wget(self, file_link, timeout):
         url = await self._resolve_url(file_link)
-        return await super()._wget_file_to_memory(url, timeout)
+        return await super()._download_file_via_wget(url, timeout)

--- a/il_supermarket_scarper/engines/engine.py
+++ b/il_supermarket_scarper/engines/engine.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
-import os
 import re
-import uuid
+import requests
 import datetime
 import asyncio
 from typing import AsyncGenerator, Optional
@@ -10,7 +9,7 @@ from il_supermarket_scarper.utils import (
     FileTypesFilters,
     Logger,
     ScraperStatus,
-    session_with_cookies,
+    session_request,
     url_retrieve_to_memory,
     wget_file_to_memory,
     RestartSessionError,
@@ -119,7 +118,7 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
             chain.value, status_database=status_database, file_output=file_output
         )
 
-        self.assigned_cookie = f"{self.chain.name}_{uuid.uuid4()}_cookies.txt"
+        self._session = requests.Session()
         self.storage_path: FileOutput = file_output
         Logger.info(
             f"Initialized {self.chain.value} scraper with"
@@ -471,24 +470,23 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
                 state.unique_seen.add(k)
                 yield item
 
-    async def session_with_cookies_by_chain(
+    async def request_with_session(
         self, url, method="GET", body=None, timeout=15, headers=None
     ):
-        """request resource with cookie by chain name"""
+        """request resource with engine session"""
         return await asyncio.to_thread(
-            session_with_cookies,
+            session_request,
             url,
-            chain_cookie_name=self.assigned_cookie,
-            timeout=timeout,
+            session=self._session,
             method=method,
+            timeout=timeout,
             body=body,
             headers=headers,
         )
 
     async def _post_scraping(self):
         """job to do post scraping"""
-        if os.path.exists(self.assigned_cookie):
-            os.remove(self.assigned_cookie)
+        self._session.close()
         await self.storage_path.close()
 
     def _validate_scraper_params(self, limit=None, files_types=None, store_id=None):

--- a/il_supermarket_scarper/engines/engine.py
+++ b/il_supermarket_scarper/engines/engine.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
 import re
-import requests
 import datetime
 import asyncio
 from typing import AsyncGenerator, Optional
+import requests
 from il_supermarket_scarper.utils import (
     FileEntry,
     FileTypesFilters,
@@ -750,13 +750,13 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
                 yield entry
 
     @async_url_connection_retry()
-    async def retrieve_file_to_memory(self, file_link, timeout=30):
+    async def download_file(self, file_link, timeout=30):
         """download file directly to memory"""
         return await asyncio.to_thread(
-            url_retrieve_to_memory, file_link, timeout=timeout
+            url_retrieve_to_memory, file_link, self._session, timeout=timeout
         )
 
-    async def _wget_file_to_memory(self, file_link, timeout):
+    async def _download_file_via_wget(self, file_link, timeout):
         return await wget_file_to_memory(file_link, timeout)
 
     async def save_and_extract(self, arg):
@@ -780,11 +780,11 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
 
             # Download file content directly to memory
             try:
-                file_content = await self.retrieve_file_to_memory(file_link, timeout=30)
+                file_content = await self.download_file(file_link, timeout=30)
 
             except Exception as e:  # pylint: disable=broad-except
                 Logger.warning(f"Error downloading {file_link}: {e}")
-                file_content = await self._wget_file_to_memory(file_link, timeout=30)
+                file_content = await self._download_file_via_wget(file_link, timeout=30)
             downloaded = True
 
             # Log file size if it's a gzip file

--- a/il_supermarket_scarper/engines/multipage_web.py
+++ b/il_supermarket_scarper/engines/multipage_web.py
@@ -99,7 +99,7 @@ class MultiPageWeb(WebBase):
             files_types=files_types, store_id=store_id, when_date=when_date
         ):
 
-            main_page_response = await self.session_with_cookies_by_chain(
+            main_page_response = await self.request_with_session(
                 **main_page_request
             )
 
@@ -280,7 +280,7 @@ class MultiPageWeb(WebBase):
     ):
         """additional processing to the links before download"""
 
-        response = await self.session_with_cookies_by_chain(**request)
+        response = await self.request_with_session(**request)
 
         html = lxml_html.fromstring(response.text)
 

--- a/il_supermarket_scarper/engines/web.py
+++ b/il_supermarket_scarper/engines/web.py
@@ -106,7 +106,7 @@ class WebBase(Engine):
         )
         try:
             async for url in gen:
-                req_res = await self.session_with_cookies_by_chain(**url)
+                req_res = await self.request_with_session(**url)
                 current_trs = self.get_data_from_page(req_res)
                 async for file_entry in self.extract_task_from_entry(current_trs):
                     yield file_entry

--- a/il_supermarket_scarper/scrappers/super_pharm.py
+++ b/il_supermarket_scarper/scrappers/super_pharm.py
@@ -36,23 +36,6 @@ class SuperPharm(MultiPageWeb):
             file_sizes.append(None)  # Super Pharm don't support file size in the entry
         return links, filenames, file_sizes
 
-    @async_url_connection_retry()
-    async def retrieve_file_to_memory(self, file_link, timeout=15):
-        """Retrieve file from Super Pharm website"""
-        Logger.debug(f"On a new Session: calling {file_link}")
-
-        response_content = await self.session_with_cookies_by_chain(
-            file_link, timeout=timeout
-        )
-        spath = json.loads(response_content.content)
-        Logger.debug(f"Found spath: {spath}")
-
-        file_to_save = await self.session_with_cookies_by_chain(
-            self.url + spath["href"], timeout=timeout
-        )
-
-        return file_to_save.content
-
     def get_file_types_id(self, files_types=None):
         """get the file type id"""
         if files_types is None:

--- a/il_supermarket_scarper/scrappers/super_pharm.py
+++ b/il_supermarket_scarper/scrappers/super_pharm.py
@@ -1,11 +1,8 @@
 import urllib.parse
 import datetime
 
-import json
 from il_supermarket_scarper.engines import MultiPageWeb
 from il_supermarket_scarper.utils import (
-    Logger,
-    async_url_connection_retry,
     DumpFolderNames,
     FileTypesFilters,
 )

--- a/il_supermarket_scarper/utils/__init__.py
+++ b/il_supermarket_scarper/utils/__init__.py
@@ -28,7 +28,7 @@ from .connection import (
     download_connection_retry,
     url_connection_retry,
     disable_when_outside_israel,
-    session_with_cookies,
+    session_request,
     url_retrieve_to_memory,
     collect_from_ftp,
     fetch_file_from_ftp_to_memory,

--- a/il_supermarket_scarper/utils/connection.py
+++ b/il_supermarket_scarper/utils/connection.py
@@ -1,9 +1,7 @@
 import contextlib
 import io
-import os
 import time
 import socket
-import pickle
 import random
 import asyncio
 import fnmatch
@@ -263,61 +261,40 @@ def get_random_user_agent():
 @url_connection_retry(
     init_timeout=60
 )  # Increased default to handle slow servers like Shufersal
-def session_with_cookies(
-    url, timeout=15, chain_cookie_name=None, method="GET", body=None, headers=None
+def session_request(
+    url, session, method="GET", timeout=15, body=None, headers=None
 ):
     """
-    Request resource with cookies enabled.
+    Request resource with given session.
 
     Parameters:
     - url: URL to request
-    - timeout: Request timeout
-    - chain_cookie_name: Optional, name for saving/loading cookies
+    - session: session object to make request
     - method: HTTP method, defaults to GET
+    - timeout: Request timeout
     - body: Data to be sent in the request body (for POST or PUT requests)
     - headers: Optional dict of custom headers to include in the request
     """
-
-    session = requests.Session()
-    if chain_cookie_name:
-
-        try:
-            with open(chain_cookie_name, "rb") as f:
-                session.cookies.update(pickle.load(f))
-            # session.cookies.load()
-        except FileNotFoundError:
-            Logger.debug("Didn't find cookie file")
-        except Exception as e:
-            # There was an issue with reading the file.
-            os.remove(chain_cookie_name)
-            raise e
-
+    
     Logger.debug(
-        f"On a new Session requesting url: method={method}, url={url}, body={body}"
+        f"On Session requesting url: method={method}, url={url}, body={body}"
     )
 
-    if method == "POST":
-        response_content = session.post(
-            url, data=body, timeout=timeout, headers=headers
-        )
-    else:
-        response_content = session.get(url, timeout=timeout, headers=headers)
+    response = session.request(
+        method, url, data=body, timeout=timeout, headers=headers
+    )
 
-    if response_content.status_code != 200:
+    if response.status_code != 200:
         Logger.debug(
-            f"On Session, got status code: {response_content.status_code}"
-            f", body is {response_content.text} "
+            f"On Session, got status code: {response.status_code}"
+            f", body is {response.text} "
         )
         raise ConnectionError(
             f"Response for {url}, returned with status"
-            f" {response_content.status_code}"
+            f" {response.status_code}"
         )
 
-    if chain_cookie_name and not os.path.exists(chain_cookie_name):
-        with open(chain_cookie_name, "wb") as f:
-            pickle.dump(session.cookies.get_dict(), f)
-
-    return response_content
+    return response
 
 
 def get_from_playwrite(page, extraction_type):

--- a/il_supermarket_scarper/utils/connection.py
+++ b/il_supermarket_scarper/utils/connection.py
@@ -275,7 +275,7 @@ def session_request(
     - body: Data to be sent in the request body (for POST or PUT requests)
     - headers: Optional dict of custom headers to include in the request
     """
-    
+
     Logger.debug(
         f"On Session requesting url: method={method}, url={url}, body={body}"
     )
@@ -403,10 +403,10 @@ def get_from_webpage(cached_page, extraction_type):
     return content
 
 
-def url_retrieve_to_memory(url, timeout=30, chunk_size=8192):
+def url_retrieve_to_memory(url, session, timeout=30, chunk_size=8192):
     """Download URL content directly to memory (BytesIO)."""
     with contextlib.closing(
-        requests.get(
+        session.get(
             url, stream=True, timeout=timeout, headers={"Accept-Encoding": None}
         )
     ) as _request:


### PR DESCRIPTION
This replaces the cookie persistence approach with requests.Session for cleaner HTTP handling.

Also removed the override of `retrieve_file_to_memory` in SuperPharm scraper since the server changed its behavior and it was falling back to wget anyway.