### PR TITLE
fix: update MahsaniAShuk test store_id from 98 to 263

### DIFF
--- a/il_supermarket_scarper/scrappers/tests/test_all.py
+++ b/il_supermarket_scarper/scrappers/tests/test_all.py
@@ -66,7 +66,7 @@ class Maayan2000TestCase(make_test_case(ScraperFactory.MAAYAN_2000, 60)):
     """Test case for ScraperFactory.MAAYAN_2000."""
 
 
-class MahsaniAShukTestCase(make_test_case(ScraperFactory.MAHSANI_ASHUK, 98)):
+class MahsaniAShukTestCase(make_test_case(ScraperFactory.MAHSANI_ASHUK, 263)):
     """Test case for ScraperFactory.MAHSANI_ASHUK."""
 
 


### PR DESCRIPTION
Branch 98 (Eilat) stopped publishing price files to laibcatalog.co.il around May 15, causing `test_scrape_file_from_single_store` to fail for 3 consecutive days in CI. The branch still appears in the site dropdown but has no active file uploads.

Changed the store_id to branch 263 (Natanya Benjamin), which is currently the most active branch with 124 files published. The other MahsaniAShuk tests (test_scrape_one, test_scrape_three, etc.) were unaffected because they do not filter by store.