### PR TITLE
Enable City Market Kiryat Gat scraper

### DIFF
--- a/il_supermarket_scarper/scraper_stability.py
+++ b/il_supermarket_scarper/scraper_stability.py
@@ -135,7 +135,7 @@ class CityMarketKiratOno(FullyStable):
 
 
 class CityMarketKiratGat(FullyStable):
-    """Netiv Hased is stablity"""
+    """Stability rules for the City Market Kiryat Gat source."""
 
     @classmethod
     def pass_expiration_date(cls):
@@ -151,15 +151,12 @@ class CityMarketKiratGat(FullyStable):
     def failire_valid(
         cls, when_date=None, files_types=None, utilize_date_param=True, **_
     ):
-        """return true if the parser is stble"""
-        return (
-            super(cls, CityMarketKiratGat).failire_valid(
-                when_date=when_date,
-                files_types=files_types,
-                utilize_date_param=utilize_date_param,
-            )
-            or True
-        )  # there is an active issue with the site
+        """Apply the standard timing safeguard without disabling the source."""
+        return super(cls, CityMarketKiratGat).failire_valid(
+            when_date=when_date,
+            files_types=files_types,
+            utilize_date_param=utilize_date_param,
+        )
 
 
 class DoNotPublishStores(FullyStable):

--- a/il_supermarket_scarper/tests/test_scrappers_factory.py
+++ b/il_supermarket_scarper/tests/test_scrappers_factory.py
@@ -1,11 +1,24 @@
 from il_supermarket_scarper import ScraperStability, ScraperFactory, datetime_in_tlv
-from il_supermarket_scarper.utils import _is_saturday_in_israel
+from il_supermarket_scarper import scraper_stability as scraper_stability_module
+from il_supermarket_scarper.utils import FileTypesFilters, _is_saturday_in_israel
 
 
 def test_stable_scraper():
     """test sample stable scarper"""
     assert not ScraperStability.is_validate_scraper_found_no_files(
         ScraperFactory.VICTORY_NEW_SOURCE.name
+    )
+
+
+def test_city_market_kiryat_gat_is_active(monkeypatch):
+    """City Market's Bina source should not be unconditionally disabled."""
+    test_date = datetime_in_tlv(2024, 12, 12, 12, 0, 0)
+    monkeypatch.setattr(scraper_stability_module, "_now", lambda: test_date)
+
+    assert not ScraperStability.is_validate_scraper_found_no_files(
+        ScraperFactory.CITY_MARKET_KIRYATGAT.name,
+        files_types=[FileTypesFilters.STORE_FILE.name],
+        when_date=test_date,
     )
 
 
@@ -17,14 +30,15 @@ def test_stable_scraper():
 #     )
 
 
-def test_not_active():
+def test_not_active(monkeypatch):
     """test grap between active and not"""
-    test_date = datetime_in_tlv(2024, 12, 12, 0, 0, 0)
+    test_date = datetime_in_tlv(2024, 12, 12, 12, 0, 0)
+    monkeypatch.setattr(scraper_stability_module, "_now", lambda: test_date)
     all_listed = ScraperFactory.all_listed_scrappers()
     all_active = ScraperFactory.all_scrapers_name(when_date=test_date)
 
-    # 'CityMarketKiratGat', 'Quik' and 'Victory' are expected to fail
-    expected_to_fail = 3
+    # 'Quik' and 'Victory' are expected to fail
+    expected_to_fail = 2
     if _is_saturday_in_israel(test_date):
         expected_to_fail += 1  # only 'NetivHased' should
 


### PR DESCRIPTION
## What changed

- remove the unconditional `or True` failure override for `CITY_MARKET_KIRYATGAT`
- retain the standard early-morning availability safeguard
- add a regression test proving Store-file runs are not permanently disabled
- make the active-scraper count test deterministic by fixing its simulated execution time

## Why

The City Market Kiryat Gat source is currently publishing downloadable files, including Store files for chain `7290058266241`. The scraper was nevertheless excluded before discovery because its stability rule always returned true and carried a stale March 2027 suppression deadline.

## Impact

`CITY_MARKET_KIRYATGAT` will participate in normal scraper runs again. Existing timing protections remain in place.

## Validation

- focused scraper-factory tests: 3 passed
- Black formatting check: passed
- production parser wrapper against `StoresFull7290058266241-000-202607221000.xml`: 28 rows parsed, including stores 11 and 80
- broader local unit selection: 15 passed; one unrelated status-page test could not run because the local Playwright browser binary is not installed
