### PR TITLE
Fix weekend weekly-release dispatch without a git checkout.

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -108,5 +108,7 @@ jobs:
             echo "Not weekend (DOW=${DOW}); skipping weekly release."
             exit 0
           fi
-          gh workflow run weekly-release.yml --ref "${{ github.ref_name }}"
+          gh workflow run weekly-release.yml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.ref_name }}"
           echo "Dispatched weekly-release.yml"


### PR DESCRIPTION
gh workflow run needs --repo when the job has no checkout, otherwise it fails looking for .git.