### PR TITLE
fix(ci): create an issue whenever pytest fails

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -49,13 +49,19 @@ jobs:
         id: test_result
         if: always()
         env:
-          PYTEST_CONCLUSION: ${{ steps.pytest.conclusion }}
+          # continue-on-error: true rewrites conclusion to "success".
+          # outcome is the real pytest result (failure vs success).
+          PYTEST_OUTCOME: ${{ steps.pytest.outcome }}
         run: |
-          if [ "$PYTEST_CONCLUSION" = "failure" ]; then
-            echo "failed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "failed=false" >> "$GITHUB_OUTPUT"
+          failed=false
+          if [ "$PYTEST_OUTCOME" = "failure" ]; then
+            failed=true
           fi
+          if [ -f pytest-log.txt ] && grep -qE '^(FAILED |ERROR )' pytest-log.txt; then
+            failed=true
+          fi
+          echo "failed=${failed}" >> "$GITHUB_OUTPUT"
+          echo "pytest outcome=${PYTEST_OUTCOME} failed=${failed}"
       - name: Upload pytest log
         if: steps.test_result.outputs.failed == 'true'
         uses: actions/upload-artifact@v4
@@ -69,7 +75,10 @@ jobs:
 
   create-issue:
     needs: build
-    if: failure() && needs.build.outputs.pytest_failed == 'true'
+    # Always open an issue when pytest failed. Do not use failure() alone:
+    # continue-on-error used to mark the pytest step successful, so the
+    # build job stayed green and this job was skipped.
+    if: always() && needs.build.result != 'cancelled' && needs.build.outputs.pytest_failed == 'true'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Same bug as [parsers#68](https://github.com/OpenIsraeliSupermarkets/israeli-supermarket-parsers/pull/68).

`Test with pytest` uses `continue-on-error: true`. That keeps the job going so we can upload logs, but GitHub then sets `steps.pytest.conclusion` to `success` even when pytest exits 1. The record step checked `conclusion`, so `pytest_failed` stayed false, the fail step was skipped, and `create-issue` (`if: failure() && ...`) was skipped.

This change:

- Treats `steps.pytest.outcome` as the real result (and also treats `FAILED` / `ERROR` lines in `pytest-log.txt` as failure).
- Runs `create-issue` whenever `pytest_failed` is true, including when the build job itself was reported green.
- Leaves a green pytest run unchanged: no issue, weekly release still gated on `success()`.

Contract: a run is either green, or it fails **and** opens a CI issue.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-110884f7-66c5-48e6-8712-4fc1efc753f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-110884f7-66c5-48e6-8712-4fc1efc753f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

