### PR TITLE
fix(ci): open failure issues only on scheduled/manual runs

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -78,7 +78,12 @@ jobs:
     # Always open an issue when pytest failed. Do not use failure() alone:
     # continue-on-error used to mark the pytest step successful, so the
     # build job stayed green and this job was skipped.
-    if: always() && needs.build.result != 'cancelled' && needs.build.outputs.pytest_failed == 'true'
+    if: >
+      always()
+      && needs.build.result != 'cancelled'
+      && needs.build.outputs.pytest_failed == 'true'
+      && github.event_name != 'pull_request'
+      && github.event_name != 'push'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Same as [parsers#70](https://github.com/OpenIsraeliSupermarkets/israeli-supermarket-parsers/pull/70).

## Summary
- Detect pytest failure from step `outcome` (not `conclusion`) and from `FAILED`/`ERROR` lines in the log, then still fail the build job (already on `main` from #131).
- Open a CI issue (and maintainer webhook) when pytest fails, but **not** on `pull_request` or `push` — only `schedule` / `workflow_dispatch`.

## Test plan
- [ ] Confirm a PR/push run with failing tests does **not** open a GitHub issue
- [ ] Confirm a scheduled or `workflow_dispatch` run with failing tests **does** open (or comment on) a deduped issue
- [ ] Confirm a cancelled build still skips issue creation
- [ ] Confirm weekend weekly-release still only runs when the test job succeeds on schedule
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-110884f7-66c5-48e6-8712-4fc1efc753f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-110884f7-66c5-48e6-8712-4fc1efc753f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

