### PR TITLE
Specify Python version compatibility in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     ],
     # Needed for dependencies
     install_requires=required,
+    python_requires=">=3.8,<3.13",
     tests_require=dev_required,
     extras_require={"test": ["pytest", "pytest-xdist"]},
     # *strongly* suggested for sharing


### PR DESCRIPTION
Add python_requires upper bound to avoid lxml source-build failures on 3.13+