### PR TITLE
Guard fcntl import for Windows compatibility

### DIFF
--- a/il_supermarket_scarper/utils/file_cache.py
+++ b/il_supermarket_scarper/utils/file_cache.py
@@ -1,9 +1,13 @@
-import fcntl
 import hashlib
-import os
 import json
+import os
 import time
 from functools import wraps
+
+if os.name == "posix":
+    import fcntl
+else:
+    fcntl = None
 
 _CACHE_DIR = ".cache"
 


### PR DESCRIPTION
Guard fcntl import so the package imports on Windows