### PR TITLE
Fix: Detect compressed files by magic bytes instead of filename

### DIFF
--- a/il_supermarket_scarper/utils/__init__.py
+++ b/il_supermarket_scarper/utils/__init__.py
@@ -1,4 +1,4 @@
-from .gzip_utils import extract_xml_from_gz_in_memory
+from .gzip_utils import extract_xml_from_gz_in_memory, is_compressed_content
 from .logger import Logger
 from .status import (
     get_output_folder,

--- a/il_supermarket_scarper/utils/file_output.py
+++ b/il_supermarket_scarper/utils/file_output.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, AsyncGenerator
 import os
 from .logger import Logger
-from .gzip_utils import extract_xml_from_gz_in_memory
+from .gzip_utils import extract_xml_from_gz_in_memory, GZIP_MAGIC_BYTES, ZIP_MAGIC_BYTES
 
 
 class FileOutput(ABC):
@@ -39,17 +39,26 @@ class FileOutput(ABC):
         """
         Extract compressed content if needed.
 
+        Detects compression by content magic bytes (gzip: 0x1f8b, zip: PK)
+        rather than filename extension, since some servers return compressed
+        content under filenames without .gz extension.
+
         Returns:
             (content, filename, extraction_success)
         """
-        if not extract_gz or not file_name.endswith(".gz"):
+        is_compressed = len(file_content) >= 2 and file_content[:2] in (
+            GZIP_MAGIC_BYTES,
+            ZIP_MAGIC_BYTES,
+        )
+        if not extract_gz or not is_compressed:
             return file_content, file_name, True
 
         try:
             extracted = await asyncio.to_thread(
                 extract_xml_from_gz_in_memory, file_content, file_name
             )
-            new_name = os.path.splitext(file_name)[0] + ".xml"
+            base_name = file_name[:-3] if file_name.endswith(".gz") else file_name
+            new_name = os.path.splitext(base_name)[0] + ".xml"
             return extracted, new_name, True
         except Exception as e:  # pylint: disable=broad-except
             Logger.error(f"Failed to extract {file_name}: {e}")
@@ -103,9 +112,11 @@ class DiskFileOutput(FileOutput):
         error = None
 
         try:
-            # Extract if it's a .gz file
+            # Extract if it's compressed
             file_content, file_name, extract_successfully = (
-                await self._extract_if_compressed(file_content, file_name)
+                await self._extract_if_compressed(
+                    file_content, file_name, self.extract_gz
+                )
             )
 
             # Write file content to disk

--- a/il_supermarket_scarper/utils/file_output.py
+++ b/il_supermarket_scarper/utils/file_output.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, AsyncGenerator
 import os
 from .logger import Logger
-from .gzip_utils import extract_xml_from_gz_in_memory, GZIP_MAGIC_BYTES, ZIP_MAGIC_BYTES
+from .gzip_utils import extract_xml_from_gz_in_memory, is_compressed_content
 
 
 class FileOutput(ABC):
@@ -46,11 +46,7 @@ class FileOutput(ABC):
         Returns:
             (content, filename, extraction_success)
         """
-        is_compressed = len(file_content) >= 2 and file_content[:2] in (
-            GZIP_MAGIC_BYTES,
-            ZIP_MAGIC_BYTES,
-        )
-        if not extract_gz or not is_compressed:
+        if not extract_gz or not is_compressed_content(file_content):
             return file_content, file_name, True
 
         try:
@@ -168,6 +164,7 @@ class QueueFileOutput(FileOutput):
         self,
         queue_handler: "AbstractQueueHandler",
         storage_path: str = "/tmp/il_supermarket_status",
+        extract_gz: bool = True,
     ):
         """
         Initialize queue file output.
@@ -175,9 +172,11 @@ class QueueFileOutput(FileOutput):
         Args:
             queue_handler: An implementation of AbstractQueueHandler
             storage_path: Path for storing status files (default: /tmp/il_supermarket_status)
+            extract_gz: Whether to extract compressed files before sending to queue
         """
         self.queue_handler: AbstractQueueHandler = queue_handler
         self.storage_path = storage_path
+        self.extract_gz = extract_gz
         os.makedirs(storage_path, exist_ok=True)
 
     async def save_file(
@@ -187,15 +186,17 @@ class QueueFileOutput(FileOutput):
         file_content: bytes,
         metadata: Dict[str, Any] = None,
     ) -> Dict[str, Any]:
-        """Send file to queue, extracting gzipped files first."""
+        """Send file to queue, extracting compressed files first."""
         saved = False
         extract_successfully = False
         error = None
 
         try:
-            # Extract if it's a .gz file
+            # Extract if it's compressed (detected by magic bytes)
             file_content, file_name, extract_successfully = (
-                await self._extract_if_compressed(file_content, file_name)
+                await self._extract_if_compressed(
+                    file_content, file_name, self.extract_gz
+                )
             )
             # Send file to queue
             if extract_successfully:

--- a/il_supermarket_scarper/utils/gzip_utils.py
+++ b/il_supermarket_scarper/utils/gzip_utils.py
@@ -8,6 +8,25 @@ GZIP_MAGIC_BYTES = b"\x1f\x8b"
 ZIP_MAGIC_BYTES = b"PK"
 
 
+def is_compressed_content(data: bytes) -> bool:
+    """
+    Check if the given data is compressed (gzip or zip) by examining magic bytes.
+
+    This detects compression by content rather than filename, which is important
+    because some servers (e.g., KingStore, SuperSapir) return gzip-compressed
+    content under filenames that don't end in .gz.
+
+    Args:
+        data: The file content to check
+
+    Returns:
+        True if the data starts with gzip (0x1f8b) or zip (PK) magic bytes
+    """
+    if len(data) < 2:
+        return False
+    return data[:2] in (GZIP_MAGIC_BYTES, ZIP_MAGIC_BYTES)
+
+
 def extract_xml_from_gz_in_memory(source_file, file_name):
     """Extract xml from gz file or stream"""
 

--- a/il_supermarket_scarper/utils/tests/test_file_output.py
+++ b/il_supermarket_scarper/utils/tests/test_file_output.py
@@ -75,6 +75,65 @@ class TestFileOutput:
 
         asyncio.run(run_test())
 
+    def test_queue_file_output_extracts_gzip_without_extension(self):
+        """Test queue output extracts gzip content without .gz extension."""
+
+        async def run_test():
+            handler = InMemoryQueueHandler("test_queue")
+            output = QueueFileOutput(handler, extract_gz=True)
+
+            xml_content = b"<xml>test content</xml>"
+            gzip_content = gzip.compress(xml_content)
+
+            result = await output.save_file(
+                file_link="http://example.com/Stores7290058108879-000",
+                file_name="Stores7290058108879-000",
+                file_content=gzip_content,
+                metadata={"chain": "KingStore"},
+            )
+
+            assert result["saved"] is True
+            assert result["extract_successfully"] is True
+            assert result["file_name"] == "Stores7290058108879-000.xml"
+
+            # Verify extracted content was sent
+            async for message in handler.get_all_messages():
+                assert message["file_name"] == "Stores7290058108879-000.xml"
+                assert message["file_content"] == xml_content
+                break
+            await handler.close()
+
+        asyncio.run(run_test())
+
+    def test_queue_file_output_respects_extract_gz_false(self):
+        """Test queue output preserves compressed content when extract_gz=False."""
+
+        async def run_test():
+            handler = InMemoryQueueHandler("test_queue")
+            output = QueueFileOutput(handler, extract_gz=False)
+
+            xml_content = b"<xml>test content</xml>"
+            gzip_content = gzip.compress(xml_content)
+
+            result = await output.save_file(
+                file_link="http://example.com/test.xml.gz",
+                file_name="test.xml.gz",
+                file_content=gzip_content,
+                metadata={"chain": "test"},
+            )
+
+            assert result["saved"] is True
+            assert result["file_name"] == "test.xml.gz"
+
+            # Verify compressed content was sent
+            async for message in handler.get_all_messages():
+                assert message["file_name"] == "test.xml.gz"
+                assert message["file_content"] == gzip_content
+                break
+            await handler.close()
+
+        asyncio.run(run_test())
+
     def test_scraper_config_defaults(self):
         """Test ScraperConfig default values."""
         config = ScraperConfig()

--- a/il_supermarket_scarper/utils/tests/test_file_output.py
+++ b/il_supermarket_scarper/utils/tests/test_file_output.py
@@ -1,6 +1,7 @@
 """Tests for file output configuration."""
 
 import asyncio
+import gzip
 import os
 import tempfile
 
@@ -141,6 +142,122 @@ class TestFileOutput:
         handler = InMemoryQueueHandler("myqueue")
         queue = QueueFileOutput(handler)
         assert queue.get_output_location() == "queue:memory:myqueue"
+
+    def test_disk_output_extracts_gzip_with_gz_extension(self):
+        """Test that gzip files with .gz extension are extracted."""
+
+        async def run_test():
+            with tempfile.TemporaryDirectory() as tmpdir:
+                output = DiskFileOutput(tmpdir, extract_gz=True)
+
+                xml_content = b"<xml>test content</xml>"
+                gzip_content = gzip.compress(xml_content)
+
+                result = await output.save_file(
+                    file_link="http://example.com/test.xml.gz",
+                    file_name="test.xml.gz",
+                    file_content=gzip_content,
+                    metadata={"chain": "test"},
+                )
+
+                assert result["saved"] is True
+                assert result["extract_successfully"] is True
+                assert result["file_name"] == "test.xml"
+                assert os.path.exists(os.path.join(tmpdir, "test.xml"))
+
+                with open(os.path.join(tmpdir, "test.xml"), "rb") as f:
+                    content = f.read()
+                    assert content == xml_content
+
+        asyncio.run(run_test())
+
+    def test_disk_output_extracts_gzip_without_gz_extension(self):
+        """Test that gzip files WITHOUT .gz extension are still extracted.
+
+        This is the bug fix for KingStore/SuperSapir where servers return
+        gzip-compressed content under filenames that don't end in .gz.
+        """
+
+        async def run_test():
+            with tempfile.TemporaryDirectory() as tmpdir:
+                output = DiskFileOutput(tmpdir, extract_gz=True)
+
+                xml_content = b"<xml>test content</xml>"
+                gzip_content = gzip.compress(xml_content)
+
+                result = await output.save_file(
+                    file_link="http://example.com/Stores7290058108879-000",
+                    file_name="Stores7290058108879-000",
+                    file_content=gzip_content,
+                    metadata={"chain": "KingStore"},
+                )
+
+                assert result["saved"] is True
+                assert result["extract_successfully"] is True
+                assert result["file_name"] == "Stores7290058108879-000.xml"
+                assert os.path.exists(
+                    os.path.join(tmpdir, "Stores7290058108879-000.xml")
+                )
+
+                with open(
+                    os.path.join(tmpdir, "Stores7290058108879-000.xml"), "rb"
+                ) as f:
+                    content = f.read()
+                    assert content == xml_content
+
+        asyncio.run(run_test())
+
+    def test_disk_output_does_not_extract_uncompressed_content(self):
+        """Test that uncompressed content is saved as-is."""
+
+        async def run_test():
+            with tempfile.TemporaryDirectory() as tmpdir:
+                output = DiskFileOutput(tmpdir, extract_gz=True)
+
+                xml_content = b"<xml>test content</xml>"
+
+                result = await output.save_file(
+                    file_link="http://example.com/test.xml",
+                    file_name="test.xml",
+                    file_content=xml_content,
+                    metadata={"chain": "test"},
+                )
+
+                assert result["saved"] is True
+                assert result["extract_successfully"] is True
+                assert result["file_name"] == "test.xml"
+
+                with open(os.path.join(tmpdir, "test.xml"), "rb") as f:
+                    content = f.read()
+                    assert content == xml_content
+
+        asyncio.run(run_test())
+
+    def test_disk_output_respects_extract_gz_false(self):
+        """Test that extract_gz=False preserves compressed content."""
+
+        async def run_test():
+            with tempfile.TemporaryDirectory() as tmpdir:
+                output = DiskFileOutput(tmpdir, extract_gz=False)
+
+                xml_content = b"<xml>test content</xml>"
+                gzip_content = gzip.compress(xml_content)
+
+                result = await output.save_file(
+                    file_link="http://example.com/test.xml.gz",
+                    file_name="test.xml.gz",
+                    file_content=gzip_content,
+                    metadata={"chain": "test"},
+                )
+
+                assert result["saved"] is True
+                assert result["file_name"] == "test.xml.gz"
+
+                with open(os.path.join(tmpdir, "test.xml.gz"), "rb") as f:
+                    content = f.read()
+                    assert content == gzip_content
+
+        asyncio.run(run_test())
 
 
 if __name__ == "__main__":

--- a/il_supermarket_scarper/utils/tests/test_gzip_utils.py
+++ b/il_supermarket_scarper/utils/tests/test_gzip_utils.py
@@ -1,7 +1,13 @@
+import gzip
 import os
 import pytest
 
-from il_supermarket_scarper.utils.gzip_utils import extract_xml_from_gz_in_memory
+from il_supermarket_scarper.utils.gzip_utils import (
+    extract_xml_from_gz_in_memory,
+    is_compressed_content,
+    GZIP_MAGIC_BYTES,
+    ZIP_MAGIC_BYTES,
+)
 
 
 def test_unzip_bad_file():
@@ -18,3 +24,50 @@ def test_unzip_bad_file():
 
     with pytest.raises(ValueError):
         extract_xml_from_gz_in_memory(file_content, file_name)
+
+
+class TestIsCompressedContent:
+    """Tests for the is_compressed_content utility function."""
+
+    def test_detects_gzip_content(self):
+        """Test that gzip-compressed content is detected."""
+        xml_content = b"<xml>test content</xml>"
+        gzip_content = gzip.compress(xml_content)
+
+        assert is_compressed_content(gzip_content) is True
+
+    def test_detects_zip_magic_bytes(self):
+        """Test that zip magic bytes (PK) are detected."""
+        zip_content = ZIP_MAGIC_BYTES + b"rest of zip file content"
+
+        assert is_compressed_content(zip_content) is True
+
+    def test_detects_uncompressed_xml(self):
+        """Test that plain XML content is not detected as compressed."""
+        xml_content = b"<xml>test content</xml>"
+
+        assert is_compressed_content(xml_content) is False
+
+    def test_detects_uncompressed_text(self):
+        """Test that plain text is not detected as compressed."""
+        text_content = b"This is plain text content"
+
+        assert is_compressed_content(text_content) is False
+
+    def test_handles_empty_content(self):
+        """Test that empty content returns False."""
+        assert is_compressed_content(b"") is False
+
+    def test_handles_single_byte(self):
+        """Test that single byte content returns False."""
+        assert is_compressed_content(b"\x1f") is False
+
+    def test_exact_gzip_magic_bytes(self):
+        """Test detection with exact gzip magic bytes."""
+        content = GZIP_MAGIC_BYTES + b"rest of content"
+        assert is_compressed_content(content) is True
+
+    def test_exact_zip_magic_bytes(self):
+        """Test detection with exact zip magic bytes."""
+        content = ZIP_MAGIC_BYTES + b"rest of content"
+        assert is_compressed_content(content) is True


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the data corruption bug described in the original issue where some chains (KingStore, SuperSapir, and potentially others) return gzip-compressed bytes under filenames that don't end in `.gz`. Previously, these files were saved as raw compressed bytes and silently skipped by parsers because they lacked the `.xml` extension.

## Changes

### `il_supermarket_scarper/utils/gzip_utils.py`
- **Added `is_compressed_content(data: bytes) -> bool`**: New reusable utility function that detects compression by examining magic bytes (gzip: `0x1f8b`, zip: `PK`). This centralizes the compression detection logic for use across the codebase.

### `il_supermarket_scarper/utils/file_output.py`
- **`_extract_if_compressed()`**: Refactored to use the new `is_compressed_content()` utility instead of inline magic byte comparison
- **`DiskFileOutput.save_file()`**: Fixed to pass `self.extract_gz` parameter (was previously using default `True` regardless of constructor setting)
- **`QueueFileOutput`**: Added `extract_gz` parameter to constructor for consistency with `DiskFileOutput`

### `il_supermarket_scarper/utils/__init__.py`
- Exported `is_compressed_content` for use by other modules

### Tests
- **`test_gzip_utils.py`**: Added 8 tests for `is_compressed_content()` covering gzip, zip, plain XML/text, empty content, and edge cases
- **`test_file_output.py`**: Added 6 tests covering gzip extraction with/without `.gz` extension, uncompressed content, and `extract_gz=False` behavior for both `DiskFileOutput` and `QueueFileOutput`

## Technical Details

The fix detects compression by content rather than filename:

```python
def is_compressed_content(data: bytes) -> bool:
    if len(data) < 2:
        return False
    return data[:2] in (GZIP_MAGIC_BYTES, ZIP_MAGIC_BYTES)
```

This is now reusable anywhere compression detection is needed.

## Testing

All 22 tests pass:
- 9 tests in `test_gzip_utils.py`
- 13 tests in `test_file_output.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67ceb620-859f-420a-a24f-6d1dea3fcd7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67ceb620-859f-420a-a24f-6d1dea3fcd7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

