### PR TITLE
Fix Windows compatibility: guard fcntl import and usage

### DIFF
--- a/il_supermarket_scarper/utils/file_cache.py
+++ b/il_supermarket_scarper/utils/file_cache.py
@@ -8,7 +8,7 @@ from functools import wraps
 if os.name == "posix":
     import fcntl
 else:
-    fcntl = None
+    fcntl = None  # pylint: disable=invalid-name
 
 _CACHE_DIR = ".cache"
 

--- a/il_supermarket_scarper/utils/file_cache.py
+++ b/il_supermarket_scarper/utils/file_cache.py
@@ -1,9 +1,14 @@
-import fcntl
 import hashlib
 import os
 import json
 import time
 from functools import wraps
+
+# fcntl is POSIX-only; skip file locking on Windows
+if os.name == "posix":
+    import fcntl
+else:
+    fcntl = None
 
 _CACHE_DIR = ".cache"
 
@@ -50,21 +55,30 @@ def file_cache(ttl=None):
 
             # Slow path: acquire exclusive per-key lock, then re-check
             os.makedirs(_CACHE_DIR, exist_ok=True)
-            lock_path = get_lock_file(func.__name__, cache_key)
-            with open(lock_path, "w", encoding="utf-8") as lock_f:
-                fcntl.flock(lock_f, fcntl.LOCK_EX)
-                try:
-                    cache = load_cache(cache_file)
-                    entry = cache.get(cache_key)
-                    if entry and _is_valid(entry):
-                        return entry["result"]
 
-                    result = func(*args, **kwargs)
-                    cache[cache_key] = {"result": result, "timestamp": time.time()}
-                    save_cache(cache_file, cache)
-                    return result
-                finally:
-                    fcntl.flock(lock_f, fcntl.LOCK_UN)
+            if fcntl:
+                # POSIX: use file locking to prevent concurrent fetches
+                lock_path = get_lock_file(func.__name__, cache_key)
+                with open(lock_path, "w", encoding="utf-8") as lock_f:
+                    fcntl.flock(lock_f, fcntl.LOCK_EX)
+                    try:
+                        cache = load_cache(cache_file)
+                        entry = cache.get(cache_key)
+                        if entry and _is_valid(entry):
+                            return entry["result"]
+
+                        result = func(*args, **kwargs)
+                        cache[cache_key] = {"result": result, "timestamp": time.time()}
+                        save_cache(cache_file, cache)
+                        return result
+                    finally:
+                        fcntl.flock(lock_f, fcntl.LOCK_UN)
+            else:
+                # Non-POSIX (e.g., Windows): skip locking, just fetch and cache
+                result = func(*args, **kwargs)
+                cache[cache_key] = {"result": result, "timestamp": time.time()}
+                save_cache(cache_file, cache)
+                return result
 
         def generate_cache_key(args, kwargs):
             key_parts = []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes the Windows compatibility issue where importing the package fails with `ModuleNotFoundError: No module named 'fcntl'`.

## Problem

`fcntl` is a POSIX-only standard library module (Linux/macOS) that doesn't exist on Windows. The module was imported unconditionally at the top of `il_supermarket_scarper/utils/file_cache.py`, causing the package to fail to import on any Windows system.

## Solution

- Conditionally import `fcntl` only on POSIX systems using `os.name == "posix"`
- Guard the `fcntl.flock()` calls to only execute when `fcntl` is available
- On non-POSIX systems (Windows), the file cache still works but without inter-process file locking

This is safe because:
1. The cached functions are idempotent network lookups
2. The worst case on Windows is that concurrent processes might refetch the same data, which just wastes a bit of bandwidth

## Testing

- Verified the module imports successfully on Linux
- Verified the `file_cache` decorator works correctly (caching and TTL)
- Existing utils tests pass

## Alternative Considered

Using a cross-platform file-locking library like `filelock` from PyPI would provide locking on Windows too, but this minimal fix avoids adding a new dependency and resolves the import failure.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbf3741b-1058-42fe-9628-33057dd39ac8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbf3741b-1058-42fe-9628-33057dd39ac8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

