### PR TITLE
Add active_folder_names() to DumpFolderNames, mark retired chains

### DIFF
--- a/il_supermarket_scarper/utils/folders_name.py
+++ b/il_supermarket_scarper/utils/folders_name.py
@@ -7,7 +7,7 @@ class DumpFolderNames(Enum):
     BAREKET = "Bareket"
     # YAYNO_BITAN = "YaynotBitan"
     YAYNO_BITAN_AND_CARREFOUR = "YaynotBitanAndCarrefour"
-    COFIX = "Cofix"
+    COFIX = "Cofix"  # deprecated: folded into Rami Levy (gov.il, 12.08.2026)
     CITY_MARKET_GIVATAYIM = "CityMarketGivatayim"
     CITY_MARKET_KIRYATONO = "CityMarketKiryatOno"
     CITY_MARKET_KIRYATGAT = "CityMarketKiryatGat"
@@ -15,12 +15,12 @@ class DumpFolderNames(Enum):
     DOR_ALON = "DorAlon"
     GOOD_PHARM = "GoodPharm"
     HAZI_HINAM = "HaziHinam"
-    HET_COHEN = "HetCohen"
+    HET_COHEN = "HetCohen"  # deprecated: use HET_COHEN_NEW_SOURCE
     HET_COHEN_NEW_SOURCE = "HetCohenNewSource"
     KESHET = "Keshet"
     KING_STORE = "KingStore"
     MAAYAN_2000 = "Maayan2000"
-    MAHSANI_ASHUK = "MahsaniAShuk"
+    MAHSANI_ASHUK = "MahsaniAShuk"  # deprecated: use MAHSANI_ASHUK_NEW_SOURCE
     MAHSANI_ASHUK_NEW_SOURCE = "MahsaniAShukNewSource"
     MEGA = "Mega"
     NETIV_HASED = "NetivHased"
@@ -38,9 +38,9 @@ class DumpFolderNames(Enum):
     SUPER_YUDA = "SuperYuda"
     SUPER_SAPIR = "SuperSapir"
     FRESH_MARKET_AND_SUPER_DOSH = "FreshMarketAndSuperDosh"
-    QUIK = "Quik"
+    QUIK = "Quik"  # deprecated: folded into Rami Levy (gov.il, 12.08.2026)
     TIV_TAAM = "TivTaam"
-    VICTORY = "Victory"
+    VICTORY = "Victory"  # deprecated: use VICTORY_NEW_SOURCE
     VICTORY_NEW_SOURCE = "VictoryNewSource"
     YELLOW = "Yellow"
     YOHANANOF = "Yohananof"
@@ -54,5 +54,11 @@ class DumpFolderNames(Enum):
 
     @classmethod
     def all_folders_names(cls):
-        """get the name of all listed folders"""
+        """get the name of all listed folders (including deprecated ones)"""
         return [e.name for e in cls]
+
+    @classmethod
+    def active_folder_names(cls):
+        """get the name of folders whose scraper is still active in ScraperFactory"""
+        deprecated = {"COFIX", "QUIK", "HET_COHEN", "MAHSANI_ASHUK", "VICTORY"}
+        return [e.name for e in cls if e.name not in deprecated]


### PR DESCRIPTION
Cofix, Quik, HetCohen, MahsaniAShuk, and Victory are commented out of ScraperFactory (retired/replaced), but DumpFolderNames still lists all five as valid folder names. Consumers that default to all_folders_names() when no explicit chain list is given (e.g. il_supermarket_parsers) scan for folders that can never exist, producing permanent no-op status entries.

Adds inline comments marking the deprecated entries and a new active_folder_names() classmethod that excludes them, alongside the existing all_folders_names() (left unchanged for backward compatibility).