### PR TITLE
Use GitHub App installation token for weekly release

### DIFF
--- a/.github/WEEKLY_RELEASE_SECRETS.md
+++ b/.github/WEEKLY_RELEASE_SECRETS.md
@@ -1,29 +1,58 @@
-# Secrets for weekly hybrid release (configure in GitHub repo Settings → Secrets)
+# Secrets for weekly hybrid release
 
-## israeli-supermarket-scarpers
-| Secret | Required | Purpose |
-|--------|----------|---------|
-| `CURSOR_MAINTAINER_WEBHOOK` | for maintainer | POST after new CI issue |
-| `CURSOR_WEBHOOK_SECRET` | optional | Bearer token for webhook |
-| `PARSERS_REPO_TOKEN` | for sync issue | PAT with `issues:write` on parsers |
-| `PARSERS_MAINTAINER_WEBHOOK` | for sync | parsers maintainer webhook URL (same as parsers `CURSOR_MAINTAINER_WEBHOOK`) |
-| `PARSERS_MAINTAINER_WEBHOOK_SECRET` | optional | Bearer for that webhook |
-| `RELEASE_GITHUB_TOKEN` | if main protected | PAT to push version bump + tags |
-| `DAILY_PUBLISH_DISPATCH_TOKEN` | for coordinator signal + deps issues | PAT with `actions:write` (repo dispatch) and `issues:write` on daily-publish |
+Primary auth is a **GitHub App** (installation token minted each job). It does not expire.
+Configure once at the **org** (Settings → Secrets and variables → Actions). Grant repository access to these three repos (or all private).
 
-## israeli-supermarket-parsers
-| Secret | Required | Purpose |
-|--------|----------|---------|
-| `CURSOR_MAINTAINER_WEBHOOK` | for maintainer | POST after new CI / sync issue |
-| `CURSOR_WEBHOOK_SECRET` | optional | Bearer token |
-| `RELEASE_GITHUB_TOKEN` | if main protected | PAT to push version bump + tags |
-| `DAILY_PUBLISH_DISPATCH_TOKEN` | for coordinator signal | same as scrapers |
+## GitHub App (required)
 
-## daily-publish-supermarket-data
-| Secret | Required | Purpose |
-|--------|----------|---------|
-| `WEEKLY_COORDINATOR_TOKEN` | yes | PAT: read Actions on scrapers+parsers; push branch + open PR here |
+| Name | Where | Purpose |
+|------|--------|---------|
+| `APP_CLIENT_ID` | Org **variable** | GitHub App client ID |
+| `APP_PRIVATE_KEY` | Org **secret** | App private key (PEM). Rotate only if leaked. |
+
+### Create and install (one-time)
+
+1. Org → Settings → Developer settings → GitHub Apps → **New GitHub App**.
+2. Suggested name: `ois-release`. Homepage: `https://github.com/OpenIsraeliSupermarkets`.
+3. Uncheck **Webhook → Active** (this App is for API tokens only).
+4. Repository permissions:
+   - **Actions:** Read (coordinator `gh run list`)
+   - **Contents:** Read and write (checkout, push, tags, releases, `repository_dispatch`)
+   - **Issues:** Read and write (parsers sync + daily-publish deps issues)
+   - **Pull requests:** Read and write (coordinator bump PR)
+   - **Metadata:** Read (default)
+5. Install on this account only, then **Install** on:
+   - `israeli-supermarket-scarpers`
+   - `israeli-supermarket-parsers`
+   - `daily-publish-supermarket-data`
+6. Generate a **private key**, paste the PEM into org secret `APP_PRIVATE_KEY`.
+7. Copy the App **Client ID** into org variable `APP_CLIENT_ID`.
+8. On **scrapers** and **parsers** `main` branch protection: **Allow specified actors to bypass required pull requests** → add `ois-release` (or whatever you named the App). `github.token` cannot push to protected `main`; the App can if it is a bypass actor.
+
+Workflows mint a 1-hour installation token with `actions/create-github-app-token` when `APP_CLIENT_ID` is set, scoped to those three repos.
+
+## Cursor Automations (still secrets)
+
+| Secret | Repo(s) | Purpose |
+|--------|---------|---------|
+| `CURSOR_MAINTAINER_WEBHOOK` | scrapers, parsers, daily-publish | POST after a new CI / sync / deps issue |
+| `CURSOR_WEBHOOK_SECRET` | same | optional Bearer |
+| `PARSERS_MAINTAINER_WEBHOOK` | scrapers | parsers maintainer URL (same as parsers `CURSOR_MAINTAINER_WEBHOOK`) |
+| `PARSERS_MAINTAINER_WEBHOOK_SECRET` | scrapers | optional Bearer |
+
+## Deprecated PAT fallbacks
+
+Used only when `APP_CLIENT_ID` is unset. Delete after the App path is green.
+
+| Secret | Repo(s) | Purpose |
+|--------|---------|---------|
+| `RELEASE_GITHUB_TOKEN` | scrapers, parsers | PAT to push version bump + tags |
+| `PARSERS_REPO_TOKEN` | scrapers | PAT with `issues:write` on parsers |
+| `DAILY_PUBLISH_DISPATCH_TOKEN` | scrapers, parsers | PAT: `contents:write` (repo dispatch) + `issues:write` on daily-publish |
+| `WEEKLY_COORDINATOR_TOKEN` | daily-publish | PAT: read Actions on scrapers+parsers; push branch + open PR |
 
 ## Cursor Automations (manual)
+
 1. Scrapers: webhook trigger → maintainer (CI issues).
 2. Parsers: webhook trigger → maintainer (CI + `[sync]` issues; may noop).
+3. Daily-publish: webhook trigger → maintainer (`[deps]` issues from scrapers/parsers releases).

--- a/.github/scripts/weekly_release.sh
+++ b/.github/scripts/weekly_release.sh
@@ -2,7 +2,7 @@
 # Change-gate weekly release: noop if no commits since last v* tag; else tag and release.
 # Bumps setup.py patch only when it still matches the latest v* tag (skip if already bumped).
 # Re-runnable: an existing tag or release is reused instead of failing.
-# Env: GITHUB_TOKEN (contents write), GITHUB_REPOSITORY
+# Env: GH_TOKEN / GITHUB_TOKEN (contents write; App installation token or PAT), GITHUB_REPOSITORY
 # Outputs via GITHUB_OUTPUT when present: outcome=noop|released, version=...
 set -euo pipefail
 

--- a/.github/workflows/notify-daily-publish-deps.yml
+++ b/.github/workflows/notify-daily-publish-deps.yml
@@ -11,18 +11,32 @@ jobs:
   open-daily-publish-deps-issue:
     runs-on: ubuntu-latest
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        if: ${{ vars.APP_CLIENT_ID != '' }}
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            israeli-supermarket-scarpers
+            israeli-supermarket-parsers
+            daily-publish-supermarket-data
       - name: Checkout scripts
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token || github.token }}
       - name: Create daily-publish dependency issue
         env:
-          GH_TOKEN: ${{ secrets.DAILY_PUBLISH_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.DAILY_PUBLISH_DISPATCH_TOKEN }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_URL: ${{ github.event.release.html_url }}
           SOURCE_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "DAILY_PUBLISH_DISPATCH_TOKEN is required to open an issue on daily-publish."
+            echo "App token or DAILY_PUBLISH_DISPATCH_TOKEN is required to open an issue on daily-publish."
             exit 1
           fi
           export PACKAGE_NAME="il-supermarket-scraper"

--- a/.github/workflows/notify-parsers-sync.yml
+++ b/.github/workflows/notify-parsers-sync.yml
@@ -11,11 +11,25 @@ jobs:
   open-parsers-sync-issue:
     runs-on: ubuntu-latest
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        if: ${{ vars.APP_CLIENT_ID != '' }}
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            israeli-supermarket-scarpers
+            israeli-supermarket-parsers
+            daily-publish-supermarket-data
       - name: Checkout scripts
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token || github.token }}
       - name: Create parsers sync issue
         env:
-          GH_TOKEN: ${{ secrets.PARSERS_REPO_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.PARSERS_REPO_TOKEN }}
           CURSOR_MAINTAINER_WEBHOOK: ${{ secrets.PARSERS_MAINTAINER_WEBHOOK }}
           CURSOR_WEBHOOK_SECRET: ${{ secrets.PARSERS_MAINTAINER_WEBHOOK_SECRET }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
@@ -23,7 +37,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "PARSERS_REPO_TOKEN is required to open a sync issue on parsers."
+            echo "App token or PARSERS_REPO_TOKEN is required to open a sync issue on parsers."
             exit 1
           fi
           TAG="${RELEASE_TAG#v}"

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -26,11 +26,23 @@ jobs:
       outcome: ${{ steps.run.outputs.outcome }}
       version: ${{ steps.run.outputs.version }}
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        if: ${{ vars.APP_CLIENT_ID != '' }}
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            israeli-supermarket-scarpers
+            israeli-supermarket-parsers
+            daily-publish-supermarket-data
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.RELEASE_GITHUB_TOKEN || github.token }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -38,18 +50,18 @@ jobs:
       - name: Weekly release (change gate + bump + tag)
         id: run
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RELEASE_GITHUB_TOKEN || github.token }}
         run: |
           chmod +x .github/scripts/weekly_release.sh
           .github/scripts/weekly_release.sh
       - name: Signal daily-publish coordinator
         if: always() && (steps.run.outputs.outcome == 'noop' || steps.run.outputs.outcome == 'released')
         env:
-          GH_TOKEN: ${{ secrets.DAILY_PUBLISH_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.DAILY_PUBLISH_DISPATCH_TOKEN }}
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "DAILY_PUBLISH_DISPATCH_TOKEN unset; skip coordinator signal."
+            echo "No App token or DAILY_PUBLISH_DISPATCH_TOKEN; skip coordinator signal."
             exit 0
           fi
           ISO_WEEK=$(date -u +%G-W%V)


### PR DESCRIPTION
## Summary
- Mint a 1-hour GitHub App installation token (`actions/create-github-app-token@v3`) for weekly release, parsers sync, and daily-publish deps notify.
- Stop depending on 30-day PATs (`RELEASE_GITHUB_TOKEN`, `PARSERS_REPO_TOKEN`, `DAILY_PUBLISH_DISPATCH_TOKEN`) except as fallback when `APP_CLIENT_ID` is unset.
- Document App setup in `.github/WEEKLY_RELEASE_SECRETS.md`.

Companion PRs: parsers + daily-publish `chore/github-app-installation-token`.

## Setup before this unblocks weekly release
The workflows merge cleanly without the App, but checkout will still fail until these exist:

1. Create org GitHub App `ois-release` (webhook **inactive**). Permissions: Actions read, Contents write, Issues write, Pull requests write.
2. Install it on scrapers, parsers, and daily-publish.
3. Org variable `APP_CLIENT_ID` + org secret `APP_PRIVATE_KEY` (grant the three repos).
4. Add the App as a **bypass actor** on scrapers/parsers `main` branch protection.

## Test plan
- [ ] App installed; org var/secret set; bypass actor added
- [ ] Merge this PR (and the two companions)
- [ ] `gh workflow run weekly-release.yml --ref main` — checkout succeeds; noop or release
- [ ] After a green run, delete the deprecated PAT secrets


Made with [Cursor](https://cursor.com)