### PR TITLE
Use GitHub App tokens and pin CI to the ci runner

### DIFF
--- a/.github/workflows/latency-compare.yml
+++ b/.github/workflows/latency-compare.yml
@@ -33,7 +33,9 @@ env:
 
 jobs:
   compare:
-    runs-on: self-hosted
+    runs-on:
+      - self-hosted
+      - ci
     # Non-mandatory: workflow is reported as neutral/success even on regressions.
     continue-on-error: true
     steps:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -18,7 +18,9 @@ permissions:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on:
+      - self-hosted
+      - ci
     outputs:
       pytest_failed: ${{ steps.test_result.outputs.failed }}
     steps:


### PR DESCRIPTION
## Summary
- Mint a GitHub App installation token for weekly release, parsers sync, and daily-publish dispatch so protected-main checkout no longer depends on expiring PATs (PAT secrets remain as fallback).
- Pin pytest and latency-compare to `[self-hosted, ci]` so they cannot land on the production scrape machine.

## Test plan
- [ ] Confirm org `APP_CLIENT_ID` / `APP_PRIVATE_KEY` and that the App is installed on scrapers, parsers, and daily-publish
- [ ] Confirm the CI self-hosted runner has the `ci` label
- [ ] After merge, `gh workflow run weekly-release.yml --ref main` (or wait for weekend) and check checkout + coordinator signal use the App token
- [ ] Confirm a PR test-suite run is picked up by the `ci` runner, not production


Made with [Cursor](https://cursor.com)