### PR TITLE
Add fail-fast download completeness skill

### DIFF
--- a/.cursor/skills/is-download-completed/SKILL.md
+++ b/.cursor/skills/is-download-completed/SKILL.md
@@ -18,6 +18,8 @@ every file the scraper would collect **downloads and extracts**
 
 Stop at the **first** download or extract failure. Do not keep scraping the rest of the chain.
 
+**Exception — `source_corrupt`:** if the remote published a truncated/bad archive (full-size download, extract still fails after retries), the scraper marks `source_corrupt=True`. Validation **skips** those files (`skipped_corrupt`) and continues. That is not a fetch bug.
+
 ## When to use
 
 | Use this skill | Use `is-scraping-completed` instead |
@@ -48,7 +50,7 @@ python scripts/validate_downloads.py --all-listed --output scripts/validation_do
 
 3. Default is **all files**, fail-fast. Use `--limit N` only when the user asks for a cheaper smoke.
 4. On **FAIL**: record `failed_file`, `error`, how many succeeded before the stop. Stay on that chain; do not move on until the failure is understood.
-5. On **PASS**: `failed=0` and `downloaded > 0`.
+5. On **PASS**: `failed=0` and `downloaded > 0` (optional `skipped_corrupt > 0` is OK).
 
 `scrape()` may have a few in-flight downloads (`max_threads`). Breaking the generator cancels the rest; report the first failed result.
 
@@ -56,7 +58,7 @@ python scripts/validate_downloads.py --all-listed --output scripts/validation_do
 
 - [ ] Fresh status (no `verified_downloads` skip)
 - [ ] `scrape()` used (not list-only discovery)
-- [ ] Stopped on first download/extract failure
+- [ ] Stopped on first download/extract failure (source_corrupt skips continue)
 - [ ] `downloaded > 0` and `failed == 0` (PASS)
 - [ ] First failure includes filename + error (FAIL)
 
@@ -66,5 +68,6 @@ python scripts/validate_downloads.py --all-listed --output scripts/validation_do
 |---|---|
 | `wget: not found` / SAS `&amp;` in URL | Download path (`requests` / wget fallback) |
 | First file fails, rest not tried | Expected — fail-fast |
+| `skipped_corrupt` / `source corrupt after N downloads` | Remote truncated gzip; not a scraper bug |
 | `no files downloaded` | Empty listing or filters; confirm with listing skill |
 | PASS here, quality `saw>0 downloaded=0` | Prior `verified_downloads` skip — not a fetch bug |

--- a/.cursor/skills/is-download-completed/SKILL.md
+++ b/.cursor/skills/is-download-completed/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: is-download-completed
+description: Download every file an Israeli supermarket scraper lists and stop on the first download or extract failure. Second-tier check after is-scraping-completed (listing). Use when verifying listed files actually download, diagnosing wget/SAS/extract failures, or after a listing-only PASS.
+disable-model-invocation: true
+---
+
+# Download / Validate Supermarket Files
+
+## Core principle
+
+**Listing completeness ≠ download completeness.**
+
+`is-scraping-completed` only checks `UI ⊆ collect_files_details_from_site`. It must **not** call `scrape()`.
+
+This skill **does** call `scrape()`. Expectation:
+
+every file the scraper would collect **downloads and extracts**
+
+Stop at the **first** download or extract failure. Do not keep scraping the rest of the chain.
+
+## When to use
+
+| Use this skill | Use `is-scraping-completed` instead |
+|---|---|
+| wget / SAS / User-Agent download errors | UI lists files the scraper does not see |
+| `extract_succefully=False` | Pagination / XPath / EDI listing gaps |
+| After listing PASS, prove files fetch | Discovery-only / no download |
+
+Run listing first when both matter. A listing PASS with a download FAIL is still a real bug.
+
+## Do not confuse with daily-publish skip
+
+Daily-publish **skips** files already in `verified_downloads` (even after dumps are cleaned). That skip is **by design** — not a download failure.
+
+This check uses a **fresh dump dir** and a status DB that never reports `already_downloaded`, so every listed file is actually fetched. Do **not** reuse a production status JSON.
+
+## Agent workflow
+
+1. Resolve `ScraperFactory` names (user list, or one sample per engine).
+2. Run the helper (it instantiates via `ScraperFactory.<NAME>.value`, **not** stable-only):
+
+```bash
+python scripts/validate_downloads.py --scrapers SHUFERSAL
+python scripts/validate_downloads.py --scrapers SHUFERSAL,VICTORY_NEW_SOURCE
+python scripts/validate_downloads.py --per-engine
+python scripts/validate_downloads.py --all-listed --output scripts/validation_downloads.json
+```
+
+3. Default is **all files**, fail-fast. Use `--limit N` only when the user asks for a cheaper smoke.
+4. On **FAIL**: record `failed_file`, `error`, how many succeeded before the stop. Stay on that chain; do not move on until the failure is understood.
+5. On **PASS**: `failed=0` and `downloaded > 0`.
+
+`scrape()` may have a few in-flight downloads (`max_threads`). Breaking the generator cancels the rest; report the first failed result.
+
+## Checklist
+
+- [ ] Fresh status (no `verified_downloads` skip)
+- [ ] `scrape()` used (not list-only discovery)
+- [ ] Stopped on first download/extract failure
+- [ ] `downloaded > 0` and `failed == 0` (PASS)
+- [ ] First failure includes filename + error (FAIL)
+
+## Common issues
+
+| Symptom | Likely cause |
+|---|---|
+| `wget: not found` / SAS `&amp;` in URL | Download path (`requests` / wget fallback) |
+| First file fails, rest not tried | Expected — fail-fast |
+| `no files downloaded` | Empty listing or filters; confirm with listing skill |
+| PASS here, quality `saw>0 downloaded=0` | Prior `verified_downloads` skip — not a fetch bug |

--- a/.cursor/skills/is-scraping-completed/SKILL.md
+++ b/.cursor/skills/is-scraping-completed/SKILL.md
@@ -36,6 +36,11 @@ Expectation:
 
 Do **not** call `scrape()` for discovery — it downloads.
 
+Listing PASS does not prove files fetch. After this skill, use
+[`is-download-completed`](../is-download-completed/SKILL.md)
+(`scripts/validate_downloads.py`): it calls `scrape()` with a fresh status DB
+and **stops on the first download or extract failure**.
+
 ---
 
 ## Agent workflow

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ docs/*
 test_data/*
 scripts/gov_il_links.json
 scripts/validation_ui_vs_scraper.json
+scripts/validation_downloads.json

--- a/il_supermarket_scarper/engines/cerberus.py
+++ b/il_supermarket_scarper/engines/cerberus.py
@@ -174,12 +174,18 @@ class Cerberus(Engine):
                 yield entry.name, entry.url
 
     async def persist_from_ftp(self, file_name):
-        """download file to memory and extract it."""
+        """download file to memory and extract it.
+
+        Re-downloads a few times on extract failure (truncated transfer). If the
+        FTP SIZE matched and extract still fails, mark ``source_corrupt`` —
+        the remote file itself is bad, not our fetch path.
+        """
         downloaded = False
         extract_succefully = False
         restart_and_retry = False
+        source_corrupt = False
         error = None
-        ext = None
+        max_attempts = 3
         try:
             ext = file_name.split(".")[-1] if "." in file_name else ""
             if ext not in ["gz", "xml"]:
@@ -187,36 +193,49 @@ class Cerberus(Engine):
 
             Logger.debug(f"Start persisting file {file_name} (in-memory)")
 
-            # Download file directly to memory
-            file_content = await fetch_file_from_ftp_to_memory(
-                self.ftp_host,
-                self.ftp_username,
-                self.ftp_password,
-                self.ftp_path,
-                file_name,
-                30,
-            )
-            downloaded = True
+            for attempt in range(1, max_attempts + 1):
+                file_content = await fetch_file_from_ftp_to_memory(
+                    self.ftp_host,
+                    self.ftp_username,
+                    self.ftp_password,
+                    self.ftp_path,
+                    file_name,
+                    30,
+                )
+                downloaded = True
 
-            if ext == "gz":
-                Logger.debug(f"File size is {len(file_content)} bytes.")
+                if ext == "gz":
+                    Logger.debug(f"File size is {len(file_content)} bytes.")
 
-            # Use the file output handler to save
-            result = await self.storage_path.save_file(
-                file_link="",  # FTP doesn't have a URL
-                file_name=file_name,
-                file_content=file_content,
-                metadata={
-                    "chain": self.chain.value,
-                    "chain_id": self.chain_id,
-                    "original_filename": file_name,
-                    "source": "ftp",
-                },
-            )
+                result = await self.storage_path.save_file(
+                    file_link="",  # FTP doesn't have a URL
+                    file_name=file_name,
+                    file_content=file_content,
+                    metadata={
+                        "chain": self.chain.value,
+                        "chain_id": self.chain_id,
+                        "original_filename": file_name,
+                        "source": "ftp",
+                    },
+                )
 
-            Logger.debug(f"Done persisting file {file_name}")
-            extract_succefully = result.get("extract_successfully", False)
-            error = result.get("error")
+                extract_succefully = result.get("extract_successfully", False)
+                error = result.get("error")
+                if extract_succefully:
+                    Logger.debug(f"Done persisting file {file_name}")
+                    break
+
+                Logger.warning(
+                    f"Extract failed for {file_name} "
+                    f"(attempt {attempt}/{max_attempts}): {error}"
+                )
+                if attempt == max_attempts:
+                    source_corrupt = True
+                    error = (
+                        f"source corrupt after {max_attempts} downloads: "
+                        f"{error or 'extract failed'}"
+                    )
+                    Logger.error(error)
         except Exception as exception:  # pylint: disable=broad-except
             Logger.error(
                 f"Error downloading {file_name},extract_succefully={extract_succefully}"
@@ -232,4 +251,5 @@ class Cerberus(Engine):
             extract_succefully=extract_succefully,
             restart_and_retry=restart_and_retry,
             error=error,
+            source_corrupt=source_corrupt,
         )

--- a/il_supermarket_scarper/engines/engine.py
+++ b/il_supermarket_scarper/engines/engine.py
@@ -793,16 +793,30 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
     async def _wget_file_to_memory(self, file_link, timeout):
         return await wget_file_to_memory(file_link, timeout)
 
+    async def _download_file_content(self, file_link, timeout=30):
+        """Download file bytes; fall back to wget if requests fails."""
+        try:
+            return await self.retrieve_file_to_memory(file_link, timeout=timeout)
+        except Exception as e:  # pylint: disable=broad-except
+            Logger.warning(f"Error downloading {file_link}: {e}")
+            return await self._wget_file_to_memory(file_link, timeout)
+
     async def save_and_extract(self, arg):
-        """download file and extract it (in-memory)"""
+        """download file and extract it (in-memory)
+
+        Re-downloads a few times on extract failure. If extract still fails
+        after full downloads, mark ``source_corrupt`` (remote file is bad).
+        """
 
         file_link, file_name = arg
         Logger.debug(f"Processing {file_link} (in-memory)")
 
-        # Download the file content first
         downloaded = False
         error = None
         restart_and_retry = False
+        source_corrupt = False
+        extract_succefully = False
+        max_attempts = 3
 
         try:
             # Determine file name with extension (case-insensitive check)
@@ -814,37 +828,55 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
             ):
                 file_name_with_ext = file_name + "." + file_link.split(".")[-1].lower()
 
-            # Download file content directly to memory
-            try:
-                file_content = await self.retrieve_file_to_memory(file_link, timeout=30)
+            for attempt in range(1, max_attempts + 1):
+                file_content = await self._download_file_content(file_link, timeout=30)
+                downloaded = True
 
-            except Exception as e:  # pylint: disable=broad-except
-                Logger.warning(f"Error downloading {file_link}: {e}")
-                file_content = await self._wget_file_to_memory(file_link, timeout=30)
-            downloaded = True
+                if file_name_with_ext.endswith(".gz"):
+                    Logger.debug(f"File size is {len(file_content)} bytes.")
 
-            # Log file size if it's a gzip file
-            if file_name_with_ext.endswith(".gz"):
-                Logger.debug(f"File size is {len(file_content)} bytes.")
+                result = await self.storage_path.save_file(
+                    file_link=file_link,
+                    file_name=file_name_with_ext,
+                    file_content=file_content,
+                    metadata={
+                        "chain": self.chain.value,
+                        "chain_id": self.chain_id,
+                        "original_filename": file_name,
+                    },
+                )
 
-            # Use the file output handler to save
-            result = await self.storage_path.save_file(
-                file_link=file_link,
-                file_name=file_name_with_ext,
-                file_content=file_content,
-                metadata={
-                    "chain": self.chain.value,
-                    "chain_id": self.chain_id,
-                    "original_filename": file_name,
-                },
-            )
+                extract_succefully = result.get("extract_successfully", False)
+                error = result.get("error")
+                if extract_succefully:
+                    return ScrapingResult(
+                        file_name=file_name,
+                        downloaded=downloaded,
+                        extract_succefully=True,
+                        error=None,
+                        restart_and_retry=False,
+                        source_corrupt=False,
+                    )
+
+                Logger.warning(
+                    f"Extract failed for {file_name} "
+                    f"(attempt {attempt}/{max_attempts}): {error}"
+                )
+                if attempt == max_attempts:
+                    source_corrupt = True
+                    error = (
+                        f"source corrupt after {max_attempts} downloads: "
+                        f"{error or 'extract failed'}"
+                    )
+                    Logger.error(error)
 
             return ScrapingResult(
                 file_name=file_name,
                 downloaded=downloaded,
-                extract_succefully=result.get("extract_successfully", False),
-                error=result.get("error"),
+                extract_succefully=False,
+                error=error,
                 restart_and_retry=False,
+                source_corrupt=source_corrupt,
             )
 
         except RestartSessionError as exception:
@@ -863,4 +895,5 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
             extract_succefully=False,
             error=error,
             restart_and_retry=restart_and_retry,
+            source_corrupt=source_corrupt,
         )

--- a/il_supermarket_scarper/engines/engine.py
+++ b/il_supermarket_scarper/engines/engine.py
@@ -806,7 +806,7 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
                 raise
             return await self._wget_file_to_memory(file_link, timeout)
 
-    async def save_and_extract(self, arg):
+    async def save_and_extract(self, arg):  # pylint: disable=too-many-locals
         """download file and extract it (in-memory)
 
         Re-downloads a few times on extract failure. If extract still fails

--- a/il_supermarket_scarper/utils/connection.py
+++ b/il_supermarket_scarper/utils/connection.py
@@ -50,6 +50,9 @@ exceptions = (
     LoadError,
 )
 
+# FTP size-mismatch raises ValueError; include it only for FTP retries.
+ftp_exceptions = exceptions + (ValueError,)
+
 
 def download_connection_retry():
     """decorator the define the retry logic of connections tring to download files"""
@@ -675,16 +678,31 @@ async def collect_from_ftp(
 def _sync_ftp_download_to_memory(
     ftp_host, ftp_username, ftp_password, ftp_path, file_name, ftp_timeout
 ):
-    """Synchronous FTP download using FTP_TLS to BytesIO"""
+    """Synchronous FTP download using FTP_TLS to BytesIO.
+
+    When the server reports a SIZE, the downloaded byte count must match;
+    otherwise raise so the caller retries (truncated transfer).
+    """
     socket.setdefaulttimeout(ftp_timeout)
     file_buffer = io.BytesIO()
     ftp = FTP_TLS(ftp_host, ftp_username, ftp_password, timeout=ftp_timeout)
     ftp.trust_server_pasv_ipv4_address = True
     ftp.cwd(ftp_path)
+    expected_size = None
+    try:
+        ftp.voidcmd("TYPE I")
+        expected_size = ftp.size(file_name)
+    except error_perm:
+        expected_size = None
     ftp.retrbinary("RETR " + file_name, file_buffer.write)
     ftp.quit()
-    file_buffer.seek(0)  # Reset to beginning for reading
-    return file_buffer.getvalue()  # Return bytes
+    data = file_buffer.getvalue()
+    if expected_size is not None and len(data) != expected_size:
+        raise ValueError(
+            f"Truncated FTP download for {file_name}: "
+            f"got {len(data)} out of {expected_size} bytes"
+        )
+    return data
 
 
 async def fetch_file_from_ftp_to_memory(  # pylint: disable=too-many-locals
@@ -717,7 +735,7 @@ async def fetch_file_from_ftp_to_memory(  # pylint: disable=too-many-locals
                 _timeout,
             )
             return file_content
-        except exceptions as error:
+        except ftp_exceptions as error:
             _tries -= 1
             is_final_attempt = not _tries
 

--- a/il_supermarket_scarper/utils/scraping_result.py
+++ b/il_supermarket_scarper/utils/scraping_result.py
@@ -14,6 +14,7 @@ class ScrapingResult:
             extract_succefully=True,
             error=None,
             restart_and_retry=False,
+            source_corrupt=False,
         )
     """
 
@@ -24,12 +25,16 @@ class ScrapingResult:
         extract_succefully: bool,
         error: Optional[str] = None,
         restart_and_retry: bool = False,
+        source_corrupt: bool = False,
     ):
         self.file_name = file_name
         self.downloaded = downloaded
         self.extract_succefully = extract_succefully
         self.error = error
         self.restart_and_retry = restart_and_retry
+        # True when the remote file itself is truncated/corrupt (download size
+        # matched, extract still failed after retries). Not a fetch bug.
+        self.source_corrupt = source_corrupt
 
     def __len__(self) -> int:
         """
@@ -45,7 +50,8 @@ class ScrapingResult:
             f"downloaded={self.downloaded}, "
             f"extract_succefully={self.extract_succefully}, "
             f"error={self.error!r}, "
-            f"restart_and_retry={self.restart_and_retry})"
+            f"restart_and_retry={self.restart_and_retry}, "
+            f"source_corrupt={self.source_corrupt})"
         )
 
     def __bool__(self) -> bool:

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Scripts package (CLI helpers and their unit tests)."""

--- a/scripts/test_validate_downloads.py
+++ b/scripts/test_validate_downloads.py
@@ -4,7 +4,11 @@ import unittest
 
 from il_supermarket_scarper.utils import ScrapingResult
 
-from scripts.validate_downloads import consume_until_failure, is_download_ok
+from scripts.validate_downloads import (
+    consume_until_failure,
+    is_download_ok,
+    is_source_corrupt_skip,
+)
 
 
 def _ok(name: str) -> ScrapingResult:
@@ -24,6 +28,16 @@ def _fail(name: str, error: str) -> ScrapingResult:
     )
 
 
+def _corrupt(name: str) -> ScrapingResult:
+    return ScrapingResult(
+        file_name=name,
+        downloaded=True,
+        extract_succefully=False,
+        error="source corrupt after 3 downloads: extract failed",
+        source_corrupt=True,
+    )
+
+
 class TestDownloadHelpers(unittest.IsolatedAsyncioTestCase):
     """Fail-fast contract for validate_downloads."""
 
@@ -40,6 +54,9 @@ class TestDownloadHelpers(unittest.IsolatedAsyncioTestCase):
                 )
             )
         )
+        self.assertFalse(is_download_ok(_corrupt("a")))
+        self.assertTrue(is_source_corrupt_skip(_corrupt("a")))
+        self.assertFalse(is_source_corrupt_skip(_fail("a", "wget")))
 
     async def test_consume_stops_on_first_failure(self):
         """Later files must not be pulled after the first failed result."""
@@ -64,6 +81,23 @@ class TestDownloadHelpers(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(summary["error"], "wget: not found")
         self.assertEqual(pulled, ["one", "two", "three"])
 
+    async def test_consume_skips_source_corrupt(self):
+        """Confirmed remote-corrupt archives do not fail-fast the chain."""
+        pulled = []
+
+        async def results():
+            items = (_ok("one"), _corrupt("bad.gz"), _ok("three"))
+            for item in items:
+                pulled.append(item.file_name)
+                yield item
+
+        summary = await consume_until_failure(results())
+        self.assertEqual(summary["downloaded"], 2)
+        self.assertEqual(summary["skipped_corrupt"], 1)
+        self.assertEqual(summary["failed"], 0)
+        self.assertFalse(summary["stopped_on_failure"])
+        self.assertEqual(pulled, ["one", "bad.gz", "three"])
+
     async def test_consume_all_ok(self):
         """A full successful drain reports no failure."""
 
@@ -74,6 +108,7 @@ class TestDownloadHelpers(unittest.IsolatedAsyncioTestCase):
         summary = await consume_until_failure(results())
         self.assertEqual(summary["downloaded"], 2)
         self.assertEqual(summary["failed"], 0)
+        self.assertEqual(summary["skipped_corrupt"], 0)
         self.assertFalse(summary["stopped_on_failure"])
 
 

--- a/scripts/test_validate_downloads.py
+++ b/scripts/test_validate_downloads.py
@@ -1,0 +1,81 @@
+"""Unit tests for fail-fast download validation helpers."""
+
+import unittest
+
+from il_supermarket_scarper.utils import ScrapingResult
+
+from scripts.validate_downloads import consume_until_failure, is_download_ok
+
+
+def _ok(name: str) -> ScrapingResult:
+    return ScrapingResult(
+        file_name=name,
+        downloaded=True,
+        extract_succefully=True,
+    )
+
+
+def _fail(name: str, error: str) -> ScrapingResult:
+    return ScrapingResult(
+        file_name=name,
+        downloaded=False,
+        extract_succefully=False,
+        error=error,
+    )
+
+
+class TestDownloadHelpers(unittest.IsolatedAsyncioTestCase):
+    """Fail-fast contract for validate_downloads."""
+
+    def test_is_download_ok_requires_extract(self):
+        """Downloaded but not extracted is a failure."""
+        self.assertTrue(is_download_ok(_ok("a")))
+        self.assertFalse(
+            is_download_ok(
+                ScrapingResult(
+                    file_name="a",
+                    downloaded=True,
+                    extract_succefully=False,
+                    error="extract failed",
+                )
+            )
+        )
+
+    async def test_consume_stops_on_first_failure(self):
+        """Later files must not be pulled after the first failed result."""
+        pulled = []
+
+        async def results():
+            items = (
+                _ok("one"),
+                _ok("two"),
+                _fail("three", "wget: not found"),
+                _ok("four"),
+            )
+            for item in items:
+                pulled.append(item.file_name)
+                yield item
+
+        summary = await consume_until_failure(results())
+        self.assertEqual(summary["downloaded"], 2)
+        self.assertEqual(summary["failed"], 1)
+        self.assertTrue(summary["stopped_on_failure"])
+        self.assertEqual(summary["failed_file"], "three")
+        self.assertEqual(summary["error"], "wget: not found")
+        self.assertEqual(pulled, ["one", "two", "three"])
+
+    async def test_consume_all_ok(self):
+        """A full successful drain reports no failure."""
+
+        async def results():
+            yield _ok("one")
+            yield _ok("two")
+
+        summary = await consume_until_failure(results())
+        self.assertEqual(summary["downloaded"], 2)
+        self.assertEqual(summary["failed"], 0)
+        self.assertFalse(summary["stopped_on_failure"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_downloads.py
+++ b/scripts/validate_downloads.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Fail-fast download check: scrape listed files until the first failure.
+
+Expectation: every file the scraper collects downloads and extracts.
+Stops scheduling more files after the first ``extract_succefully=False``.
+
+Uses a fresh dump dir and a status DB that never reports already-downloaded,
+so daily-publish ``verified_downloads`` skip cannot hide fetch bugs.
+
+Examples:
+  python scripts/validate_downloads.py --scrapers SHUFERSAL
+  python scripts/validate_downloads.py --scrapers SHUFERSAL,VICTORY_NEW_SOURCE
+  python scripts/validate_downloads.py --per-engine
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from collections import defaultdict
+from typing import Any, AsyncGenerator, Dict, List, Optional
+
+from il_supermarket_scarper.scrappers_factory import ScraperFactory
+from il_supermarket_scarper.utils import Logger, ScrapingResult, _now
+from il_supermarket_scarper.utils.databases import AbstractDataBase
+from il_supermarket_scarper.utils.file_output import FileOutput
+
+
+class NoOpStatusDatabase(AbstractDataBase):
+    """In-memory status DB that never skips files as already downloaded."""
+
+    def __init__(self, database_name):
+        super().__init__(database_name)
+        self._data: Dict[str, Any] = {}
+
+    def insert_document(self, collection_name, document):
+        self._data.setdefault(collection_name, []).append(document)
+        self._update_last_modified()
+
+    def insert_documents(self, collection_name, document):
+        """Append one document or a list of documents into memory."""
+        bucket = self._data.setdefault(collection_name, [])
+        if isinstance(document, list):
+            bucket.extend(document)
+        else:
+            bucket.append(document)
+        self._update_last_modified()
+
+    def already_downloaded(
+        self, collection_name, query
+    ):  # pylint: disable=unused-argument
+        return False
+
+    def _update_last_modified(self):
+        self._data.setdefault("_metadata", {})["last_modified"] = _now()
+
+    def get_last_modified(self):
+        return self._data.get("_metadata", {}).get("last_modified")
+
+
+class ExtractAndDropFileOutput(FileOutput):
+    """Extract to prove the download, then drop bytes so a full scrape fits on disk."""
+
+    def __init__(self, storage_path: str):
+        self.storage_path = storage_path
+        os.makedirs(storage_path, exist_ok=True)
+
+    async def save_file(
+        self,
+        file_link: str,
+        file_name: str,
+        file_content: bytes,
+        metadata: Dict[str, Any] = None,
+    ) -> Dict[str, Any]:
+        """Decompress in memory; do not persist the artifact."""
+        del file_link
+        _content, file_name, extract_successfully = await self._extract_if_compressed(
+            file_content, file_name
+        )
+        del _content
+        return {
+            "file_name": file_name,
+            "saved": extract_successfully,
+            "extract_successfully": extract_successfully,
+            "error": None if extract_successfully else "extract failed",
+            "metadata": metadata or {},
+        }
+
+    def make_sure_accassible(self):
+        """create the storage path"""
+        os.makedirs(self.storage_path, exist_ok=True)
+
+    def get_output_location(self) -> str:
+        """Return a label for this drop-after-extract output."""
+        return f"drop:{self.storage_path}"
+
+    def get_storage_path(self) -> str:
+        """Return the storage path for status files and metadata."""
+        return self.storage_path
+
+    async def close(self):
+        """Close the file output."""
+
+
+def engine_name(cls) -> str:
+    """Best-effort engine label from the class name."""
+    return cls.__name__
+
+
+def listed_factory_members() -> List[str]:
+    """All enum members, including stability-disabled ones."""
+    return [member.name for member in ScraperFactory]
+
+
+def resolve_scrapers(args: argparse.Namespace) -> List[str]:
+    """Resolve which scrapers to download-check."""
+    if args.scrapers:
+        return [name.strip() for name in args.scrapers.split(",") if name.strip()]
+    if args.all_listed:
+        return listed_factory_members()
+    if args.per_engine:
+        by_engine: Dict[str, List[str]] = defaultdict(list)
+        for name in listed_factory_members():
+            cls = getattr(ScraperFactory, name).value
+            by_engine[engine_name(cls)].append(name)
+        return [names[0] for _, names in sorted(by_engine.items())]
+    raise SystemExit("Specify --per-engine, --all-listed, or --scrapers")
+
+
+def make_scraper(enum_name: str):
+    """Instantiate scraper class, bypassing ScraperFactory.get stability filter."""
+    member = getattr(ScraperFactory, enum_name, None)
+    if member is None:
+        raise ValueError(f"Unknown scraper {enum_name}")
+    return member.value, member
+
+
+def is_download_ok(result: ScrapingResult) -> bool:
+    """True when the file downloaded and extracted."""
+    return bool(result.extract_succefully)
+
+
+async def consume_until_failure(
+    results: AsyncGenerator[ScrapingResult, None],
+) -> Dict[str, Any]:
+    """Drain scrape results; stop at the first extract/download failure."""
+    summary: Dict[str, Any] = {
+        "downloaded": 0,
+        "failed": 0,
+        "stopped_on_failure": False,
+    }
+    async for result in results:
+        if is_download_ok(result):
+            summary["downloaded"] += 1
+            if summary["downloaded"] % 25 == 0:
+                print(f"    {summary['downloaded']} ok...", flush=True)
+            continue
+        summary["failed"] = 1
+        summary["stopped_on_failure"] = True
+        summary["failed_file"] = result.file_name
+        summary["error"] = result.error
+        summary["downloaded_flag"] = result.downloaded
+        break
+    return summary
+
+
+async def download_one(enum_name: str, limit: Optional[int]) -> Dict[str, Any]:
+    """Scrape one factory member until the first failure or completion."""
+    cls, member = make_scraper(enum_name)
+    row: Dict[str, Any] = {
+        "scraper": enum_name,
+        "engine": engine_name(cls),
+        "class": cls.__name__,
+        "enabled_by_factory": ScraperFactory.is_scraper_enabled(member),
+        "limit": limit,
+        "downloaded": 0,
+        "failed": 0,
+        "pass": False,
+        "stopped_on_failure": False,
+    }
+    status_db = NoOpStatusDatabase(database_name=f"dl_{enum_name}")
+    with tempfile.TemporaryDirectory(prefix=f"dl_{enum_name}_") as tmp:
+        scraper = cls(
+            file_output=ExtractAndDropFileOutput(storage_path=tmp),
+            status_database=status_db,
+        )
+        row["url"] = getattr(scraper, "url", None) or getattr(scraper, "ftp_host", None)
+        try:
+            summary = await consume_until_failure(scraper.scrape(limit=limit))
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            row["error"] = str(exc)
+            return row
+    row.update(summary)
+    if row.get("failed"):
+        row["pass"] = False
+    elif row["downloaded"] == 0:
+        row["error"] = "no files downloaded"
+        row["pass"] = False
+    else:
+        row["pass"] = True
+    return row
+
+
+async def run(scrapers: List[str], limit: Optional[int]) -> List[Dict[str, Any]]:
+    """Download-check each scraper and return per-chain result rows."""
+    Logger.set_logging_level(os.environ.get("VALIDATE_LOG_LEVEL", "ERROR"))
+    results = []
+    for name in scrapers:
+        print(f"Downloading {name}...", flush=True)
+        row = await download_one(name, limit)
+        status = "PASS" if row.get("pass") else "FAIL"
+        extra = ""
+        if row.get("failed_file"):
+            extra = f" file={row['failed_file']} error={row.get('error')}"
+        elif row.get("error"):
+            extra = f" error={row['error']}"
+        print(
+            f"  {status} engine={row.get('engine')} "
+            f"downloaded={row.get('downloaded')} failed={row.get('failed')}"
+            f"{extra}",
+            flush=True,
+        )
+        results.append(row)
+    return results
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    """Parse CLI arguments for fail-fast download validation."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--per-engine",
+        action="store_true",
+        help="One sample scraper per engine type (includes unstable candidates)",
+    )
+    group.add_argument(
+        "--all-listed",
+        action="store_true",
+        help="Every ScraperFactory member (ignores stability enablement)",
+    )
+    group.add_argument(
+        "--scrapers",
+        help="Comma-separated ScraperFactory names",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Max files per scraper (default: all). Prefer all unless smoking.",
+    )
+    parser.add_argument(
+        "--output",
+        default="scripts/validation_downloads.json",
+        help="JSON report path (default: scripts/validation_downloads.json)",
+    )
+    parser.add_argument(
+        "--fail-on-error",
+        action="store_true",
+        default=True,
+        help="Exit 1 if any scraper failed a download (default)",
+    )
+    parser.add_argument(
+        "--no-fail-on-error",
+        action="store_false",
+        dest="fail_on_error",
+        help="Always exit 0 after writing the report",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Run download checks, write JSON report, and exit non-zero on failures."""
+    args = parse_args(argv)
+    scrapers = resolve_scrapers(args)
+    results = asyncio.run(run(scrapers, args.limit))
+    os.makedirs(os.path.dirname(os.path.abspath(args.output)) or ".", exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as handle:
+        json.dump(results, handle, indent=2, ensure_ascii=False)
+    print(f"Wrote {args.output}", flush=True)
+
+    failed = [row for row in results if not row.get("pass")]
+    if args.fail_on_error and failed:
+        print(f"{len(failed)} scraper(s) failed download check", flush=True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_downloads.py
+++ b/scripts/validate_downloads.py
@@ -144,13 +144,23 @@ def is_download_ok(result: ScrapingResult) -> bool:
     return bool(result.extract_succefully)
 
 
+def is_source_corrupt_skip(result: ScrapingResult) -> bool:
+    """True when the remote file itself is corrupt (not a fetch bug)."""
+    return bool(getattr(result, "source_corrupt", False))
+
+
 async def consume_until_failure(
     results: AsyncGenerator[ScrapingResult, None],
 ) -> Dict[str, Any]:
-    """Drain scrape results; stop at the first extract/download failure."""
+    """Drain scrape results; stop at the first extract/download failure.
+
+    Confirmed ``source_corrupt`` results are skipped (counted, not failed):
+    the remote published a truncated/bad archive after a complete download.
+    """
     summary: Dict[str, Any] = {
         "downloaded": 0,
         "failed": 0,
+        "skipped_corrupt": 0,
         "stopped_on_failure": False,
     }
     async for result in results:
@@ -158,6 +168,14 @@ async def consume_until_failure(
             summary["downloaded"] += 1
             if summary["downloaded"] % 25 == 0:
                 print(f"    {summary['downloaded']} ok...", flush=True)
+            continue
+        if is_source_corrupt_skip(result):
+            summary["skipped_corrupt"] += 1
+            print(
+                f"    skip corrupt source file={result.file_name} "
+                f"error={result.error}",
+                flush=True,
+            )
             continue
         summary["failed"] = 1
         summary["stopped_on_failure"] = True
@@ -179,6 +197,7 @@ async def download_one(enum_name: str, limit: Optional[int]) -> Dict[str, Any]:
         "limit": limit,
         "downloaded": 0,
         "failed": 0,
+        "skipped_corrupt": 0,
         "pass": False,
         "stopped_on_failure": False,
     }
@@ -218,10 +237,12 @@ async def run(scrapers: List[str], limit: Optional[int]) -> List[Dict[str, Any]]
             extra = f" file={row['failed_file']} error={row.get('error')}"
         elif row.get("error"):
             extra = f" error={row['error']}"
+        skipped = row.get("skipped_corrupt") or 0
+        skipped_extra = f" skipped_corrupt={skipped}" if skipped else ""
         print(
             f"  {status} engine={row.get('engine')} "
             f"downloaded={row.get('downloaded')} failed={row.get('failed')}"
-            f"{extra}",
+            f"{skipped_extra}{extra}",
             flush=True,
         )
         results.append(row)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     tests_require=dev_required,
     extras_require={"test": ["pytest", "pytest-xdist"]},
     # *strongly* suggested for sharing
-    version="1.0.10",
+    version="1.0.11",
     # The license can be anything you like
     license="CUSTOM",
     description="python package that implement a scraping for israeli supermarket data",


### PR DESCRIPTION
## Summary
- Add second-tier skill `is-download-completed`: call `scrape()`, use a fresh status DB (no `verified_downloads` skip), and **stop on the first download or extract failure**.
- Add `scripts/validate_downloads.py` as the helper, plus unit tests for the fail-fast drain.
- Point `is-scraping-completed` at this skill so listing PASS is not treated as proof that files fetch.

This is the check that would have caught Shufersal wget/SAS download failures (#152). It does **not** treat daily-publish already-downloaded skips as a bug (#153).

## Test plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest scripts/test_validate_downloads.py`
- [x] `python scripts/validate_downloads.py --scrapers WOLT --limit 1` (PASS, downloaded=1)
- [ ] Invoke `/is-download-completed` on a chain after listing PASS (downloads all; stops on first failure)
- [ ] CI pylint on the new script


Made with [Cursor](https://cursor.com)