### PR TITLE
Classify gzip extract failures as truncated, CRC mismatch, or not gzip

### DIFF
--- a/.cursor/skills/is-download-completed/SKILL.md
+++ b/.cursor/skills/is-download-completed/SKILL.md
@@ -68,6 +68,6 @@ python scripts/validate_downloads.py --all-listed --output scripts/validation_do
 |---|---|
 | `wget: not found` / SAS `&amp;` in URL | Download path (`requests` / wget fallback) |
 | First file fails, rest not tried | Expected — fail-fast |
-| `skipped_corrupt` / `source corrupt after N downloads` | Remote truncated gzip; not a scraper bug |
+| `skipped_corrupt` / `source corrupt after N downloads` | Remote truncated/CRC-bad gzip (`gzip truncated` / `gzip crc_mismatch`); not a scraper bug |
 | `no files downloaded` | Empty listing or filters; confirm with listing skill |
 | PASS here, quality `saw>0 downloaded=0` | Prior `verified_downloads` skip — not a fetch bug |

--- a/il_supermarket_scarper/utils/__init__.py
+++ b/il_supermarket_scarper/utils/__init__.py
@@ -1,4 +1,13 @@
-from .gzip_utils import extract_xml_from_gz_in_memory, is_compressed_content
+from .gzip_utils import (
+    extract_xml_from_gz_in_memory,
+    is_compressed_content,
+    validate_gzip_integrity,
+    GzipIntegrity,
+    GZIP_OK,
+    GZIP_TRUNCATED,
+    GZIP_CRC_MISMATCH,
+    GZIP_NOT_GZIP,
+)
 from .logger import Logger
 from .status import (
     get_output_folder,

--- a/il_supermarket_scarper/utils/file_output.py
+++ b/il_supermarket_scarper/utils/file_output.py
@@ -3,7 +3,7 @@
 import asyncio
 import multiprocessing
 from abc import ABC, abstractmethod
-from typing import Any, Dict, AsyncGenerator
+from typing import Any, Dict, AsyncGenerator, Optional, Tuple
 import os
 from .logger import Logger
 from .gzip_utils import extract_xml_from_gz_in_memory, is_compressed_content
@@ -35,7 +35,7 @@ class FileOutput(ABC):
 
     async def _extract_if_compressed(
         self, file_content: bytes, file_name: str, extract_gz: bool = True
-    ) -> tuple[bytes, str, bool]:
+    ) -> Tuple[bytes, str, bool, Optional[str]]:
         """
         Extract compressed content if needed.
 
@@ -44,10 +44,10 @@ class FileOutput(ABC):
         content under filenames without .gz extension.
 
         Returns:
-            (content, filename, extraction_success)
+            (content, filename, extraction_success, error)
         """
         if not extract_gz or not is_compressed_content(file_content):
-            return file_content, file_name, True
+            return file_content, file_name, True, None
 
         try:
             extracted = await asyncio.to_thread(
@@ -55,10 +55,10 @@ class FileOutput(ABC):
             )
             base_name = file_name[:-3] if file_name.endswith(".gz") else file_name
             new_name = os.path.splitext(base_name)[0] + ".xml"
-            return extracted, new_name, True
+            return extracted, new_name, True, None
         except Exception as e:  # pylint: disable=broad-except
             Logger.error(f"Failed to extract {file_name}: {e}")
-            return file_content, file_name, False
+            return file_content, file_name, False, str(e)
 
     @abstractmethod
     def make_sure_accassible(self):
@@ -109,11 +109,13 @@ class DiskFileOutput(FileOutput):
 
         try:
             # Extract if it's compressed
-            file_content, file_name, extract_successfully = (
+            file_content, file_name, extract_successfully, extract_error = (
                 await self._extract_if_compressed(
                     file_content, file_name, self.extract_gz
                 )
             )
+            if not extract_successfully:
+                error = extract_error
 
             # Write file content to disk
             file_save_path = os.path.join(self.storage_path, file_name)
@@ -193,11 +195,13 @@ class QueueFileOutput(FileOutput):
 
         try:
             # Extract if it's compressed (detected by magic bytes)
-            file_content, file_name, extract_successfully = (
+            file_content, file_name, extract_successfully, extract_error = (
                 await self._extract_if_compressed(
                     file_content, file_name, self.extract_gz
                 )
             )
+            if not extract_successfully:
+                error = extract_error
             # Send file to queue
             if extract_successfully:
                 message = {

--- a/il_supermarket_scarper/utils/gzip_utils.py
+++ b/il_supermarket_scarper/utils/gzip_utils.py
@@ -1,11 +1,44 @@
 import gzip
-import shutil
 import io
+import shutil
 import zipfile
+from dataclasses import dataclass
+from typing import Optional
+
 from .exceptions import RestartSessionError
 
 GZIP_MAGIC_BYTES = b"\x1f\x8b"
 ZIP_MAGIC_BYTES = b"PK"
+
+GZIP_OK = "ok"
+GZIP_TRUNCATED = "truncated"
+GZIP_CRC_MISMATCH = "crc_mismatch"
+GZIP_NOT_GZIP = "not_gzip"
+
+
+@dataclass(frozen=True)
+class GzipIntegrity:
+    """gzip member completeness + footer check.
+
+    ``status`` is one of: ok, truncated, crc_mismatch, not_gzip.
+    ``uncompressed`` is set only when status is ok.
+    """
+
+    status: str
+    detail: str = ""
+    uncompressed: Optional[bytes] = None
+
+    @property
+    def ok(self) -> bool:
+        """True when the gzip member fully decoded and CRC/ISIZE matched."""
+        return self.status == GZIP_OK
+
+    def __repr__(self) -> str:
+        length = len(self.uncompressed) if self.uncompressed is not None else None
+        return (
+            f"GzipIntegrity(status={self.status!r}, detail={self.detail!r}, "
+            f"uncompressed_len={length})"
+        )
 
 
 def is_compressed_content(data: bytes) -> bool:
@@ -27,6 +60,42 @@ def is_compressed_content(data: bytes) -> bool:
     return data[:2] in (GZIP_MAGIC_BYTES, ZIP_MAGIC_BYTES)
 
 
+def validate_gzip_integrity(data: bytes) -> GzipIntegrity:
+    """Classify gzip bytes without relying on a generic extract exception.
+
+    Distinguishes a complete valid member from a truncated stream, a CRC/ISIZE
+    footer mismatch, and non-gzip content.
+    """
+    if not data or data[:2] != GZIP_MAGIC_BYTES:
+        magic = data[:2].hex() if data else ""
+        return GzipIntegrity(
+            status=GZIP_NOT_GZIP,
+            detail=f"magic bytes: {magic or 'empty'}",
+        )
+
+    try:
+        uncompressed = gzip.decompress(data)
+    except EOFError as exc:
+        return GzipIntegrity(status=GZIP_TRUNCATED, detail=str(exc))
+    except gzip.BadGzipFile as exc:
+        return _classify_gzip_error(str(exc))
+    except OSError as exc:
+        # gzip may wrap zlib CRC/stream errors as OSError.
+        return _classify_gzip_error(str(exc))
+
+    return GzipIntegrity(status=GZIP_OK, uncompressed=uncompressed)
+
+
+def _classify_gzip_error(message: str) -> GzipIntegrity:
+    """Map gzip/zlib error text onto truncated / crc_mismatch / not_gzip."""
+    lowered = message.lower()
+    if "crc" in lowered or "incorrect length" in lowered or "data check" in lowered:
+        return GzipIntegrity(status=GZIP_CRC_MISMATCH, detail=message)
+    if "not a gzipped file" in lowered or "incorrect header" in lowered:
+        return GzipIntegrity(status=GZIP_NOT_GZIP, detail=message)
+    return GzipIntegrity(status=GZIP_TRUNCATED, detail=message)
+
+
 def extract_xml_from_gz_in_memory(source_file, file_name):
     """Extract xml from gz file or stream"""
 
@@ -36,12 +105,19 @@ def extract_xml_from_gz_in_memory(source_file, file_name):
     magic_bytes = source_buffer.read(2)
     source_buffer.seek(0)
 
-    try:
-        if magic_bytes == GZIP_MAGIC_BYTES:
-            with gzip.open(source_buffer, "rb") as infile:
-                shutil.copyfileobj(infile, output_buffer)
+    if magic_bytes == GZIP_MAGIC_BYTES:
+        integrity = validate_gzip_integrity(source_file)
+        if not integrity.ok:
+            raise ValueError(
+                f"gzip {integrity.status}: {file_name}: {integrity.detail} "
+                f"(buffer size: {len(source_file)} bytes)"
+            )
+        output_buffer.write(integrity.uncompressed)
+        output_buffer.seek(0)
+        return output_buffer.getvalue()
 
-        elif magic_bytes == ZIP_MAGIC_BYTES:
+    try:
+        if magic_bytes == ZIP_MAGIC_BYTES:
             with zipfile.ZipFile(source_buffer) as the_zip:
                 with the_zip.open(the_zip.infolist()[0]) as the_file:
                     shutil.copyfileobj(the_file, output_buffer)

--- a/il_supermarket_scarper/utils/tests/test_file_output.py
+++ b/il_supermarket_scarper/utils/tests/test_file_output.py
@@ -318,6 +318,25 @@ class TestFileOutput:
 
         asyncio.run(run_test())
 
+    def test_disk_output_reports_gzip_truncated(self):
+        """Extract failure surfaces gzip truncated instead of a blank error."""
+
+        async def run_test():
+            with tempfile.TemporaryDirectory() as tmpdir:
+                output = DiskFileOutput(tmpdir, extract_gz=True)
+                truncated = gzip.compress(b"<xml>test content</xml>")[:-20]
+                result = await output.save_file(
+                    file_link="http://example.com/test.xml.gz",
+                    file_name="test.xml.gz",
+                    file_content=truncated,
+                    metadata={"chain": "test"},
+                )
+                assert result["extract_successfully"] is False
+                assert result["error"]
+                assert "gzip truncated" in result["error"]
+
+        asyncio.run(run_test())
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/il_supermarket_scarper/utils/tests/test_gzip_utils.py
+++ b/il_supermarket_scarper/utils/tests/test_gzip_utils.py
@@ -1,29 +1,111 @@
 import gzip
 import os
+import zipfile
+import io
+
 import pytest
 
 from il_supermarket_scarper.utils.gzip_utils import (
     extract_xml_from_gz_in_memory,
     is_compressed_content,
+    validate_gzip_integrity,
     GZIP_MAGIC_BYTES,
     ZIP_MAGIC_BYTES,
+    GZIP_OK,
+    GZIP_TRUNCATED,
+    GZIP_CRC_MISMATCH,
+    GZIP_NOT_GZIP,
+)
+
+BAD_GZIP_FIXTURE = (
+    "il_supermarket_scarper/utils/tests/PriceFull7290876100000-003-202410070010.gz"
 )
 
 
+def _good_gzip(payload=b"<xml>test content</xml>"):
+    return gzip.compress(payload), payload
+
+
 def test_unzip_bad_file():
-    """test unziping a bad file"""
+    """Truncated on-disk fixture is classified as gzip truncated."""
+    file_name = os.path.basename(BAD_GZIP_FIXTURE)
+    with open(BAD_GZIP_FIXTURE, "rb") as handle:
+        file_content = handle.read()
 
-    file_path = (
-        "il_supermarket_scarper/utils/tests/PriceFull7290876100000-003-202410070010.gz"
-    )
-    file_name = "PriceFull7290876100000-003-202410070010.gz"
-    file_content = None
-    if os.path.exists(file_path):
-        with open(file_path, "rb") as f:
-            file_content = f.read()
+    integrity = validate_gzip_integrity(file_content)
+    assert integrity.status == GZIP_TRUNCATED
+    assert integrity.ok is False
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="gzip truncated"):
         extract_xml_from_gz_in_memory(file_content, file_name)
+
+
+def test_extract_valid_gzip_uses_integrity_bytes():
+    """Happy-path gzip extract returns the uncompressed payload."""
+    compressed, payload = _good_gzip()
+    assert extract_xml_from_gz_in_memory(compressed, "ok.gz") == payload
+
+
+def test_extract_valid_zip_still_works():
+    """Zip members are unchanged; integrity check is gzip-only."""
+    payload = b"<xml>zipped</xml>"
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("doc.xml", payload)
+    assert extract_xml_from_gz_in_memory(buffer.getvalue(), "ok.zip") == payload
+
+
+class TestValidateGzipIntegrity:
+    """Classify complete, truncated, CRC-bad, and non-gzip payloads."""
+
+    def test_ok_gzip(self):
+        """Complete gzip member is ok and returns uncompressed bytes."""
+        compressed, payload = _good_gzip()
+        result = validate_gzip_integrity(compressed)
+        assert result.status == GZIP_OK
+        assert result.ok is True
+        assert result.uncompressed == payload
+
+    def test_truncated_gzip(self):
+        """Dropping the gzip footer is truncated, not ok."""
+        compressed, _payload = _good_gzip()
+        result = validate_gzip_integrity(compressed[:-20])
+        assert result.status == GZIP_TRUNCATED
+        assert result.ok is False
+        assert result.uncompressed is None
+
+    def test_crc_mismatch(self):
+        """Flipping the gzip CRC footer is crc_mismatch."""
+        compressed, _payload = _good_gzip()
+        mutated = bytearray(compressed)
+        mutated[-8] ^= 0xFF
+        result = validate_gzip_integrity(bytes(mutated))
+        assert result.status == GZIP_CRC_MISMATCH
+        assert "CRC" in result.detail or "crc" in result.detail.lower()
+
+    def test_not_gzip_html(self):
+        """HTML error pages are not_gzip."""
+        result = validate_gzip_integrity(b"<html>link expired</html>")
+        assert result.status == GZIP_NOT_GZIP
+
+    def test_not_gzip_empty(self):
+        """Empty buffers are not_gzip."""
+        result = validate_gzip_integrity(b"")
+        assert result.status == GZIP_NOT_GZIP
+        assert "empty" in result.detail
+
+    def test_not_gzip_plain_xml(self):
+        """Uncompressed XML is not_gzip."""
+        result = validate_gzip_integrity(b"<?xml version='1.0'?><root/>")
+        assert result.status == GZIP_NOT_GZIP
+
+    def test_extract_crc_mismatch_message(self):
+        """Extract error text includes gzip crc_mismatch."""
+        compressed, _payload = _good_gzip()
+        mutated = bytearray(compressed)
+        mutated[-8] ^= 0xFF
+        with pytest.raises(ValueError, match="gzip crc_mismatch"):
+            extract_xml_from_gz_in_memory(bytes(mutated), "bad.gz")
 
 
 class TestIsCompressedContent:

--- a/scripts/validate_downloads.py
+++ b/scripts/validate_downloads.py
@@ -78,15 +78,19 @@ class ExtractAndDropFileOutput(FileOutput):
     ) -> Dict[str, Any]:
         """Decompress in memory; do not persist the artifact."""
         del file_link
-        _content, file_name, extract_successfully = await self._extract_if_compressed(
-            file_content, file_name
+        _content, file_name, extract_successfully, extract_error = (
+            await self._extract_if_compressed(file_content, file_name)
         )
         del _content
         return {
             "file_name": file_name,
             "saved": extract_successfully,
             "extract_successfully": extract_successfully,
-            "error": None if extract_successfully else "extract failed",
+            "error": (
+                None
+                if extract_successfully
+                else (extract_error or "extract failed")
+            ),
             "metadata": metadata or {},
         }
 


### PR DESCRIPTION
## Summary
- Add `validate_gzip_integrity` so gzip members are classified as `ok`, `truncated`, `crc_mismatch`, or `not_gzip` instead of a generic extract exception.
- Surface that status in file-output and download-validation errors (`gzip truncated` / `gzip crc_mismatch`) so remote-corrupt archives are distinguishable from scraper bugs.
- Cover the happy path, truncated fixture, CRC footer flip, and non-gzip payloads in unit tests.

## Test plan
- [ ] `pytest il_supermarket_scarper/utils/tests/test_gzip_utils.py il_supermarket_scarper/utils/tests/test_file_output.py -q`
- [ ] Confirm a truncated `.gz` now fails with `gzip truncated` rather than a blank extract error
- [ ] Confirm a CRC-flipped gzip fails with `gzip crc_mismatch`


Made with [Cursor](https://cursor.com)