### PR TITLE
Start downloads as soon as listing results arrive

### DIFF
--- a/il_supermarket_scarper/engines/api_web.py
+++ b/il_supermarket_scarper/engines/api_web.py
@@ -117,60 +117,73 @@ class ApiWebEngine(WebBase):
             except (AttributeError, KeyError, TypeError) as e:
                 Logger.warning(f"Error extracting task from entry: {e}")
 
-    async def _collect_request_infos(
-        self, files_types=None, store_id=None, when_date=None
-    ):
-        """Materialize listing request infos from get_request_url."""
-        request_infos = []
-        requests_to_make = self.get_request_url(
-            files_types=files_types, store_id=store_id, when_date=when_date
-        )
-        try:
-            async for request_info in requests_to_make:
-                if request_info:
-                    request_infos.append(request_info)
-        finally:
-            await requests_to_make.aclose()
-        return request_infos
-
-    async def _stream_api_file_entries(
+    async def _stream_api_file_entries(  # pylint: disable=too-many-locals,too-many-branches
         self, files_types=None, store_id=None, when_date=None
     ):
         """Yield FileEntry objects as each listing request completes."""
-        request_queue = await self._collect_request_infos(
+        requests_to_make = self.get_request_url(
             files_types=files_types, store_id=store_id, when_date=when_date
         )
-        flight = {"pending": set()}
+        pending = set()
         max_in_flight = max(1, self.max_threads)
         seen_names = set()
+        request_exhausted = False
+        listing_done = object()
+        listing_task = None
 
-        def schedule_requests():
-            pending = flight["pending"]
-            while len(pending) < max_in_flight and request_queue:
-                request_info = request_queue.pop(0)
-                pending.add(
-                    asyncio.create_task(
-                        asyncio.to_thread(self._fetch_entries_for_request, request_info)
-                    )
-                )
+        async def next_request():
+            try:
+                return await anext(requests_to_make)
+            except StopAsyncIteration:
+                return listing_done
 
-        schedule_requests()
         try:
-            while flight["pending"]:
-                done, flight["pending"] = await asyncio.wait(
-                    flight["pending"], return_when=asyncio.FIRST_COMPLETED
+            while True:
+                if (
+                    not request_exhausted
+                    and listing_task is None
+                    and len(pending) < max_in_flight
+                ):
+                    listing_task = asyncio.create_task(next_request())
+
+                wait_for = set(pending)
+                if listing_task is not None:
+                    wait_for.add(listing_task)
+                if not wait_for:
+                    break
+
+                done, _pending = await asyncio.wait(
+                    wait_for, return_when=asyncio.FIRST_COMPLETED
                 )
-                completed_batches = [task.result() for task in done]
-                schedule_requests()
-                for entries in completed_batches:
+
+                if listing_task is not None and listing_task in done:
+                    request_info = listing_task.result()
+                    listing_task = None
+                    if request_info is listing_done:
+                        request_exhausted = True
+                    elif request_info:
+                        pending.add(
+                            asyncio.create_task(
+                                asyncio.to_thread(
+                                    self._fetch_entries_for_request, request_info
+                                )
+                            )
+                        )
+
+                for task in done:
+                    if task not in pending:
+                        continue
+                    pending.remove(task)
                     entries = self._filter_streamed_entries(
-                        entries, files_types, seen_names
+                        task.result(), files_types, seen_names
                     )
                     async for file_entry in self.extract_task_from_entry(entries):
                         yield file_entry
         finally:
-            request_queue.clear()
-            pending = flight["pending"]
+            if listing_task is not None:
+                listing_task.cancel()
+                await asyncio.gather(listing_task, return_exceptions=True)
+            await requests_to_make.aclose()
             for task in pending:
                 task.cancel()
             if pending:

--- a/il_supermarket_scarper/engines/api_web.py
+++ b/il_supermarket_scarper/engines/api_web.py
@@ -4,6 +4,7 @@ import requests
 from il_supermarket_scarper.utils import Logger
 from il_supermarket_scarper.utils import FileEntry
 from il_supermarket_scarper.utils.state import FilterState
+from il_supermarket_scarper.utils.async_work import stream_as_completed
 from .web import WebBase
 
 
@@ -117,77 +118,33 @@ class ApiWebEngine(WebBase):
             except (AttributeError, KeyError, TypeError) as e:
                 Logger.warning(f"Error extracting task from entry: {e}")
 
-    async def _stream_api_file_entries(  # pylint: disable=too-many-locals,too-many-branches
+    async def _stream_api_file_entries(
         self, files_types=None, store_id=None, when_date=None
     ):
         """Yield FileEntry objects as each listing request completes."""
         requests_to_make = self.get_request_url(
             files_types=files_types, store_id=store_id, when_date=when_date
         )
-        pending = set()
-        max_in_flight = max(1, self.max_threads)
         seen_names = set()
-        request_exhausted = False
-        listing_done = object()
-        listing_task = None
 
-        async def next_request():
-            try:
-                return await anext(requests_to_make)
-            except StopAsyncIteration:
-                return listing_done
+        async def fetch_files(request_info):
+            raw = await asyncio.to_thread(
+                self._fetch_entries_for_request, request_info
+            )
+            entries = self._filter_streamed_entries(raw, files_types, seen_names)
+            extracted = []
+            async for file_entry in self.extract_task_from_entry(entries):
+                extracted.append(file_entry)
+            return extracted
 
-        try:
-            while True:
-                if (
-                    not request_exhausted
-                    and listing_task is None
-                    and len(pending) < max_in_flight
-                ):
-                    listing_task = asyncio.create_task(next_request())
-
-                wait_for = set(pending)
-                if listing_task is not None:
-                    wait_for.add(listing_task)
-                if not wait_for:
-                    break
-
-                done, _pending = await asyncio.wait(
-                    wait_for, return_when=asyncio.FIRST_COMPLETED
-                )
-
-                if listing_task is not None and listing_task in done:
-                    request_info = listing_task.result()
-                    listing_task = None
-                    if request_info is listing_done:
-                        request_exhausted = True
-                    elif request_info:
-                        pending.add(
-                            asyncio.create_task(
-                                asyncio.to_thread(
-                                    self._fetch_entries_for_request, request_info
-                                )
-                            )
-                        )
-
-                for task in done:
-                    if task not in pending:
-                        continue
-                    pending.remove(task)
-                    entries = self._filter_streamed_entries(
-                        task.result(), files_types, seen_names
-                    )
-                    async for file_entry in self.extract_task_from_entry(entries):
-                        yield file_entry
-        finally:
-            if listing_task is not None:
-                listing_task.cancel()
-                await asyncio.gather(listing_task, return_exceptions=True)
-            await requests_to_make.aclose()
-            for task in pending:
-                task.cancel()
-            if pending:
-                await asyncio.gather(*pending, return_exceptions=True)
+        async for file_entry in stream_as_completed(
+            requests_to_make,
+            fetch_files,
+            max(1, self.max_threads),
+            source_error_prefix="Error getting API listing URL",
+            work_error_prefix="Error listing files from API",
+        ):
+            yield file_entry
 
     async def collect_files_details_from_site(  # pylint: disable=too-many-locals
         self,

--- a/il_supermarket_scarper/engines/cerberus.py
+++ b/il_supermarket_scarper/engines/cerberus.py
@@ -142,6 +142,7 @@ class Cerberus(Engine):
                 self.ftp_password,
                 self.ftp_path,
                 filter_arg,
+                fetch_size=min_size is not None or max_size is not None,
             )
             files_generator = self.register_all_saw_files_on_site(files_generator)
 

--- a/il_supermarket_scarper/engines/engine.py
+++ b/il_supermarket_scarper/engines/engine.py
@@ -23,6 +23,7 @@ from il_supermarket_scarper.utils import (
 )
 from il_supermarket_scarper.utils.state import FilterState
 from il_supermarket_scarper.utils.databases import AbstractDataBase
+from il_supermarket_scarper.utils.async_work import stream_as_completed
 
 
 @dataclass(frozen=True)
@@ -319,8 +320,7 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
             are considered for selection.
         """
 
-        # Collect all input files first (needed for unique, latest,
-        # random_selection)
+        # Stream one file at a time; unique() and date filters are online.
         async def stream_to_list(
             state: FilterState, intreable: AsyncGenerator[FileEntry, None]
         ) -> AsyncGenerator[FileEntry, None]:
@@ -626,7 +626,7 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
             return file_details[1]
         return "unknown"
 
-    async def _scrape(  # pylint: disable=too-many-locals,too-many-branches
+    async def _scrape(  # pylint: disable=too-many-locals
         self,
         state: FilterState,
         limit=None,
@@ -676,77 +676,14 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
             random_selection=random_selection,
         )
 
-        listing_done = object()
-
-        async def next_listing_item():
-            try:
-                return await anext(files_generator)  # pylint: disable=undefined-variable
-            except StopAsyncIteration:
-                return listing_done
-
-        # Downloads start as soon as the first link arrives. Further listing
-        # is fetched concurrently with in-flight downloads instead of waiting
-        # to prefetch max_threads links first.
-        pending_tasks = {}
-        generator_exhausted = False
-        listing_task = None
-
-        try:
-            while True:
-                if (
-                    not generator_exhausted
-                    and listing_task is None
-                    and len(pending_tasks) < self.max_threads
-                ):
-                    listing_task = asyncio.create_task(next_listing_item())
-
-                wait_for = set(pending_tasks)
-                if listing_task is not None:
-                    wait_for.add(listing_task)
-                if not wait_for:
-                    break
-
-                done, _pending = await asyncio.wait(
-                    wait_for, return_when=asyncio.FIRST_COMPLETED
-                )
-
-                if listing_task is not None and listing_task in done:
-                    file_details = listing_task.result()
-                    listing_task = None
-                    if file_details is listing_done:
-                        generator_exhausted = True
-                    else:
-                        task = asyncio.create_task(
-                            process_file_with_semaphore(file_details)
-                        )
-                        pending_tasks[task] = file_details
-
-                for task in done:
-                    if task not in pending_tasks:
-                        continue
-                    file_details = pending_tasks.pop(task)
-                    try:
-                        result = await task
-                        yield result
-                    except Exception as e:  # pylint: disable=broad-except
-                        Logger.error(f"Error processing task: {e}")
-                        file_name = self._extract_file_name(file_details)
-                        yield ScrapingResult(
-                            file_name=file_name,
-                            downloaded=False,
-                            extract_succefully=False,
-                            error=str(e),
-                            restart_and_retry=False,
-                        )
-        finally:
-            if listing_task is not None:
-                listing_task.cancel()
-                await asyncio.gather(listing_task, return_exceptions=True)
-            await files_generator.aclose()
-            if pending_tasks:
-                for task in pending_tasks:
-                    task.cancel()
-                await asyncio.gather(*pending_tasks, return_exceptions=True)
+        async for result in stream_as_completed(
+            files_generator,
+            process_file_with_semaphore,
+            self.max_threads,
+            source_error_prefix="Error collecting file details",
+            work_error_prefix="Error processing download",
+        ):
+            yield result
 
     def get_chain_id(self):
         """get the chain id as list"""

--- a/il_supermarket_scarper/engines/engine.py
+++ b/il_supermarket_scarper/engines/engine.py
@@ -626,7 +626,7 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
             return file_details[1]
         return "unknown"
 
-    async def _scrape(  # pylint: disable=too-many-locals
+    async def _scrape(  # pylint: disable=too-many-locals,too-many-branches
         self,
         state: FilterState,
         limit=None,
@@ -676,65 +676,76 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
             random_selection=random_selection,
         )
 
-        # Set to track pending tasks (task -> file_details mapping)
+        listing_done = object()
+
+        async def next_listing_item():
+            try:
+                return await anext(files_generator)  # pylint: disable=undefined-variable
+            except StopAsyncIteration:
+                return listing_done
+
+        # Downloads start as soon as the first link arrives. Further listing
+        # is fetched concurrently with in-flight downloads instead of waiting
+        # to prefetch max_threads links first.
         pending_tasks = {}
         generator_exhausted = False
+        listing_task = None
 
         try:
             while True:
-                # Add new tasks from generator up to max_threads limit
-                while not generator_exhausted and len(pending_tasks) < self.max_threads:
-                    try:
-                        file_details = (
-                            await anext(  # pylint: disable=undefined-variable
-                                files_generator
-                            )
-                        )
+                if (
+                    not generator_exhausted
+                    and listing_task is None
+                    and len(pending_tasks) < self.max_threads
+                ):
+                    listing_task = asyncio.create_task(next_listing_item())
+
+                wait_for = set(pending_tasks)
+                if listing_task is not None:
+                    wait_for.add(listing_task)
+                if not wait_for:
+                    break
+
+                done, _pending = await asyncio.wait(
+                    wait_for, return_when=asyncio.FIRST_COMPLETED
+                )
+
+                if listing_task is not None and listing_task in done:
+                    file_details = listing_task.result()
+                    listing_task = None
+                    if file_details is listing_done:
+                        generator_exhausted = True
+                    else:
                         task = asyncio.create_task(
                             process_file_with_semaphore(file_details)
                         )
                         pending_tasks[task] = file_details
-                    except StopAsyncIteration:
-                        generator_exhausted = True
-                        break
 
-                # If no pending tasks and generator is exhausted, we're done
-                if not pending_tasks and generator_exhausted:
-                    break
-
-                # Wait for at least one task to complete
-                if pending_tasks:
-                    done, _pending = await asyncio.wait(
-                        pending_tasks.keys(), return_when=asyncio.FIRST_COMPLETED
-                    )
-
-                    # Process completed tasks
-                    for task in done:
-                        file_details = pending_tasks.pop(task)
-                        try:
-                            result = await task
-                            yield result
-                        except Exception as e:  # pylint: disable=broad-except
-                            Logger.error(f"Error processing task: {e}")
-                            file_name = self._extract_file_name(file_details)
-                            yield ScrapingResult(
-                                file_name=file_name,
-                                downloaded=False,
-                                extract_succefully=False,
-                                error=str(e),
-                                restart_and_retry=False,
-                            )
-                else:
-                    # No pending tasks but generator might still have items
-                    # This shouldn't happen, but break to be safe
-                    break
+                for task in done:
+                    if task not in pending_tasks:
+                        continue
+                    file_details = pending_tasks.pop(task)
+                    try:
+                        result = await task
+                        yield result
+                    except Exception as e:  # pylint: disable=broad-except
+                        Logger.error(f"Error processing task: {e}")
+                        file_name = self._extract_file_name(file_details)
+                        yield ScrapingResult(
+                            file_name=file_name,
+                            downloaded=False,
+                            extract_succefully=False,
+                            error=str(e),
+                            restart_and_retry=False,
+                        )
         finally:
-            # Clean up any remaining tasks
+            if listing_task is not None:
+                listing_task.cancel()
+                await asyncio.gather(listing_task, return_exceptions=True)
             await files_generator.aclose()
             if pending_tasks:
                 for task in pending_tasks:
                     task.cancel()
-                # Wait for cancellations to complete
                 await asyncio.gather(*pending_tasks, return_exceptions=True)
 
     def get_chain_id(self):

--- a/il_supermarket_scarper/engines/multipage_web.py
+++ b/il_supermarket_scarper/engines/multipage_web.py
@@ -1,7 +1,6 @@
 from urllib.parse import urlsplit
 import re
 import ntpath
-import asyncio
 from abc import abstractmethod
 from typing import AsyncGenerator
 from lxml import html as lxml_html
@@ -15,6 +14,7 @@ from il_supermarket_scarper.utils import (
     UnitSize,
     FilterState,
 )
+from il_supermarket_scarper.utils.async_work import stream_as_completed
 from .web import WebBase
 
 
@@ -132,9 +132,6 @@ class MultiPageWeb(WebBase):
         roots = self.get_request_url(
             files_types=files_types, store_id=store_id, when_date=when_date
         )
-        flight = {"pending": set()}
-        max_in_flight = max(1, self.max_threads)
-        exhausted = False
 
         async def resolve_root(main_page_request):
             main_page_response = await self.session_with_cookies_by_chain(
@@ -144,36 +141,16 @@ class MultiPageWeb(WebBase):
             Logger.info(f"Found {total_pages} pages")
             return self._pages_to_scrape(main_page_request, total_pages)
 
-        async def schedule_roots():
-            nonlocal exhausted
-            pending = flight["pending"]
-            while len(pending) < max_in_flight and not exhausted:
-                try:
-                    main_page_request = await anext(roots)
-                except StopAsyncIteration:
-                    exhausted = True
-                    break
-                pending.add(asyncio.create_task(resolve_root(main_page_request)))
+        async for page_req in stream_as_completed(
+            roots,
+            resolve_root,
+            max(1, self.max_threads),
+            source_error_prefix="Error getting listing root URL",
+            work_error_prefix="Error resolving listing root",
+        ):
+            yield page_req
 
-        try:
-            await schedule_roots()
-            while flight["pending"]:
-                done, flight["pending"] = await asyncio.wait(
-                    flight["pending"], return_when=asyncio.FIRST_COMPLETED
-                )
-                await schedule_roots()
-                for task in done:
-                    for page_req in task.result():
-                        yield page_req
-        finally:
-            await roots.aclose()
-            pending = flight["pending"]
-            for task in pending:
-                task.cancel()
-            if pending:
-                await asyncio.gather(*pending, return_exceptions=True)
-
-    async def _stream_page_queue(  # pylint: disable=too-many-locals,too-many-branches
+    async def _stream_page_queue(
         self,
         page_source,
         state,
@@ -184,75 +161,26 @@ class MultiPageWeb(WebBase):
         random_selection=False,
     ) -> AsyncGenerator[FileEntry, None]:
         """Yield page results with bounded in-flight fetches."""
-        # Bound in-flight page fetches, yield as each page finishes so
-        # Engine._scrape can start downloads while later pages load.
-        # aclose() cancels in-flight work after limit.
-        pending = set()
-        max_in_flight = max(1, self.max_threads)
-        source_exhausted = False
-        listing_done = object()
-        listing_task = None
 
-        async def next_page_request():
-            try:
-                return await anext(page_source)
-            except StopAsyncIteration:
-                return listing_done
-
-        def start_page(req):
-            return asyncio.create_task(
-                self._process_single_page(
-                    req,
-                    state,
-                    limit=limit,
-                    files_types=files_types,
-                    store_id=store_id,
-                    when_date=when_date,
-                    random_selection=random_selection,
-                )
+        async def process_page(req):
+            return await self._process_single_page(
+                req,
+                state,
+                limit=limit,
+                files_types=files_types,
+                store_id=store_id,
+                when_date=when_date,
+                random_selection=random_selection,
             )
 
-        try:
-            while True:
-                if (
-                    not source_exhausted
-                    and listing_task is None
-                    and len(pending) < max_in_flight
-                ):
-                    listing_task = asyncio.create_task(next_page_request())
-
-                wait_for = set(pending)
-                if listing_task is not None:
-                    wait_for.add(listing_task)
-                if not wait_for:
-                    break
-
-                done, _pending = await asyncio.wait(
-                    wait_for, return_when=asyncio.FIRST_COMPLETED
-                )
-
-                if listing_task is not None and listing_task in done:
-                    req = listing_task.result()
-                    listing_task = None
-                    if req is listing_done:
-                        source_exhausted = True
-                    else:
-                        pending.add(start_page(req))
-
-                for task in done:
-                    if task not in pending:
-                        continue
-                    pending.remove(task)
-                    for entry in task.result():
-                        yield entry
-        finally:
-            if listing_task is not None:
-                listing_task.cancel()
-                await asyncio.gather(listing_task, return_exceptions=True)
-            for task in pending:
-                task.cancel()
-            if pending:
-                await asyncio.gather(*pending, return_exceptions=True)
+        async for entry in stream_as_completed(
+            page_source,
+            process_page,
+            max(1, self.max_threads),
+            source_error_prefix="Error reading listing page queue",
+            work_error_prefix="Error fetching listing page",
+        ):
+            yield entry
 
     async def generate_all_files(
         self,

--- a/il_supermarket_scarper/engines/multipage_web.py
+++ b/il_supermarket_scarper/engines/multipage_web.py
@@ -125,9 +125,57 @@ class MultiPageWeb(WebBase):
             results.append(entry)
         return results
 
-    async def _stream_page_queue(  # pylint: disable=too-many-locals
+    async def _iter_page_requests(
+        self, files_types=None, store_id=None, when_date=None
+    ):
+        """Yield page requests as each listing root's page count is known."""
+        roots = self.get_request_url(
+            files_types=files_types, store_id=store_id, when_date=when_date
+        )
+        flight = {"pending": set()}
+        max_in_flight = max(1, self.max_threads)
+        exhausted = False
+
+        async def resolve_root(main_page_request):
+            main_page_response = await self.session_with_cookies_by_chain(
+                **main_page_request
+            )
+            total_pages = self.get_number_of_pages(main_page_response)
+            Logger.info(f"Found {total_pages} pages")
+            return self._pages_to_scrape(main_page_request, total_pages)
+
+        async def schedule_roots():
+            nonlocal exhausted
+            pending = flight["pending"]
+            while len(pending) < max_in_flight and not exhausted:
+                try:
+                    main_page_request = await anext(roots)
+                except StopAsyncIteration:
+                    exhausted = True
+                    break
+                pending.add(asyncio.create_task(resolve_root(main_page_request)))
+
+        try:
+            await schedule_roots()
+            while flight["pending"]:
+                done, flight["pending"] = await asyncio.wait(
+                    flight["pending"], return_when=asyncio.FIRST_COMPLETED
+                )
+                await schedule_roots()
+                for task in done:
+                    for page_req in task.result():
+                        yield page_req
+        finally:
+            await roots.aclose()
+            pending = flight["pending"]
+            for task in pending:
+                task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+
+    async def _stream_page_queue(  # pylint: disable=too-many-locals,too-many-branches
         self,
-        page_queue,
+        page_source,
         state,
         limit=None,
         files_types=None,
@@ -138,45 +186,69 @@ class MultiPageWeb(WebBase):
         """Yield page results with bounded in-flight fetches."""
         # Bound in-flight page fetches, yield as each page finishes so
         # Engine._scrape can start downloads while later pages load.
-        # aclose() clears the queue and cancels in-flight work after limit.
-        flight = {"pending": set()}
+        # aclose() cancels in-flight work after limit.
+        pending = set()
         max_in_flight = max(1, self.max_threads)
+        source_exhausted = False
+        listing_done = object()
+        listing_task = None
 
-        def schedule_pages():
-            pending = flight["pending"]
-            while len(pending) < max_in_flight and page_queue:
-                req = page_queue.pop(0)
-                pending.add(
-                    asyncio.create_task(
-                        self._process_single_page(
-                            req,
-                            state,
-                            limit=limit,
-                            files_types=files_types,
-                            store_id=store_id,
-                            when_date=when_date,
-                            random_selection=random_selection,
-                        )
-                    )
+        async def next_page_request():
+            try:
+                return await anext(page_source)
+            except StopAsyncIteration:
+                return listing_done
+
+        def start_page(req):
+            return asyncio.create_task(
+                self._process_single_page(
+                    req,
+                    state,
+                    limit=limit,
+                    files_types=files_types,
+                    store_id=store_id,
+                    when_date=when_date,
+                    random_selection=random_selection,
                 )
+            )
 
-        schedule_pages()
         try:
-            while flight["pending"]:
-                done, flight["pending"] = await asyncio.wait(
-                    flight["pending"], return_when=asyncio.FIRST_COMPLETED
+            while True:
+                if (
+                    not source_exhausted
+                    and listing_task is None
+                    and len(pending) < max_in_flight
+                ):
+                    listing_task = asyncio.create_task(next_page_request())
+
+                wait_for = set(pending)
+                if listing_task is not None:
+                    wait_for.add(listing_task)
+                if not wait_for:
+                    break
+
+                done, _pending = await asyncio.wait(
+                    wait_for, return_when=asyncio.FIRST_COMPLETED
                 )
-                completed_entries = []
+
+                if listing_task is not None and listing_task in done:
+                    req = listing_task.result()
+                    listing_task = None
+                    if req is listing_done:
+                        source_exhausted = True
+                    else:
+                        pending.add(start_page(req))
+
                 for task in done:
-                    completed_entries.extend(task.result())
-                # Refill slots before yielding so listing stays ahead of
-                # downloads while the consumer is busy.
-                schedule_pages()
-                for entry in completed_entries:
-                    yield entry
+                    if task not in pending:
+                        continue
+                    pending.remove(task)
+                    for entry in task.result():
+                        yield entry
         finally:
-            page_queue.clear()
-            pending = flight["pending"]
+            if listing_task is not None:
+                listing_task.cancel()
+                await asyncio.gather(listing_task, return_exceptions=True)
             for task in pending:
                 task.cancel()
             if pending:
@@ -192,22 +264,12 @@ class MultiPageWeb(WebBase):
     ) -> AsyncGenerator[FileEntry, None]:
         """generate all files from the site"""
 
-        async for main_page_request in self.get_request_url(
+        pages = self._iter_page_requests(
             files_types=files_types, store_id=store_id, when_date=when_date
-        ):
-
-            main_page_response = await self.session_with_cookies_by_chain(
-                **main_page_request
-            )
-
-            total_pages = self.get_number_of_pages(main_page_response)
-            Logger.info(f"Found {total_pages} pages")
-
-            # Shared filter state across pages (limit is applied later in
-            # collect_files_details_from_site to avoid per-page races).
-            page_queue = self._pages_to_scrape(main_page_request, total_pages)
+        )
+        try:
             async for entry in self._stream_page_queue(
-                page_queue,
+                pages,
                 FilterState(),
                 limit=limit,
                 files_types=files_types,
@@ -216,6 +278,8 @@ class MultiPageWeb(WebBase):
                 random_selection=random_selection,
             ):
                 yield entry
+        finally:
+            await pages.aclose()
 
     async def collect_files_details_from_site(  # pylint: disable=too-many-locals
         self,

--- a/il_supermarket_scarper/engines/tests/test_multipage_streaming.py
+++ b/il_supermarket_scarper/engines/tests/test_multipage_streaming.py
@@ -222,3 +222,78 @@ class TestMultiPageStreaming(unittest.IsolatedAsyncioTestCase):
                 await gen.aclose()
 
             self.assertEqual(set(rest), {"cat-2.xml"})
+
+    async def test_failed_page_does_not_drop_other_pages(self):
+        """One page fetch error must not hide files already listed on another page."""
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = _DummyMultiPage(tmp)
+            scraper.session_with_cookies_by_chain = AsyncMock(
+                return_value=MagicMock(content=b"<html></html>")
+            )
+            scraper.get_number_of_pages = MagicMock(return_value=2)
+
+            async def fake_process_links(  # pylint: disable=unused-argument
+                state,
+                request,
+                limit=None,
+                files_types=None,
+                store_id=None,
+                when_date=None,
+                random_selection=False,
+            ):
+                if "page=2" in request["url"]:
+                    raise ConnectionError("page 2 down")
+                yield FileEntry(name="page1.xml", url="http://x/1", size=1)
+
+            scraper.process_links_before_download = fake_process_links
+
+            names = []
+            gen = scraper.generate_all_files()
+            try:
+                async for entry in gen:
+                    names.append(entry.name)
+            finally:
+                await gen.aclose()
+
+            self.assertEqual(names, ["page1.xml"])
+
+    async def test_failed_listing_root_does_not_drop_other_root(self):
+        """One listing-root error must not hide files from another root."""
+
+        class _TwoRootDummy(_DummyMultiPage):
+            def build_params(self, files_types=None, store_id=None, when_date=None):
+                return ["?cat=1", "?cat=2"]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = _TwoRootDummy(tmp)
+
+            async def fake_session(**request):
+                if "cat=2" in request["url"]:
+                    raise ConnectionError("root 2 down")
+                return MagicMock(content=b"<html></html>")
+
+            scraper.session_with_cookies_by_chain = fake_session
+            scraper.get_number_of_pages = MagicMock(return_value=None)
+
+            async def fake_process_links(  # pylint: disable=unused-argument
+                state,
+                request,
+                limit=None,
+                files_types=None,
+                store_id=None,
+                when_date=None,
+                random_selection=False,
+            ):
+                yield FileEntry(name="cat-1.xml", url="http://x/1", size=1)
+
+            scraper.process_links_before_download = fake_process_links
+
+            names = []
+            gen = scraper.generate_all_files()
+            try:
+                async for entry in gen:
+                    names.append(entry.name)
+            finally:
+                await gen.aclose()
+
+            self.assertEqual(names, ["cat-1.xml"])

--- a/il_supermarket_scarper/engines/tests/test_multipage_streaming.py
+++ b/il_supermarket_scarper/engines/tests/test_multipage_streaming.py
@@ -173,3 +173,52 @@ class TestMultiPageStreaming(unittest.IsolatedAsyncioTestCase):
 
             self.assertEqual(len(results), 1)
             self.assertLessEqual(len(fetched_pages), 2)
+
+    async def test_second_listing_root_does_not_block_first(self):
+        """Files from a fast listing root must yield while another root is still loading."""
+
+        class _TwoRootDummy(_DummyMultiPage):
+            def build_params(self, files_types=None, store_id=None, when_date=None):
+                return ["?cat=1", "?cat=2"]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = _TwoRootDummy(tmp)
+            slow_root_started = asyncio.Event()
+            release_slow_root = asyncio.Event()
+
+            async def fake_session(**request):
+                if "cat=2" in request["url"]:
+                    slow_root_started.set()
+                    await release_slow_root.wait()
+                return MagicMock(content=b"<html></html>")
+
+            scraper.session_with_cookies_by_chain = fake_session
+            scraper.get_number_of_pages = MagicMock(return_value=None)
+
+            async def fake_process_links(  # pylint: disable=unused-argument
+                state,
+                request,
+                limit=None,
+                files_types=None,
+                store_id=None,
+                when_date=None,
+                random_selection=False,
+            ):
+                cat = "2" if "cat=2" in request["url"] else "1"
+                yield FileEntry(
+                    name=f"cat-{cat}.xml", url=f"http://x/{cat}", size=1
+                )
+
+            scraper.process_links_before_download = fake_process_links
+
+            gen = scraper.generate_all_files()
+            try:
+                first = await asyncio.wait_for(anext(gen), timeout=1)
+                self.assertEqual(first.name, "cat-1.xml")
+                await asyncio.wait_for(slow_root_started.wait(), timeout=1)
+                release_slow_root.set()
+                rest = [entry.name async for entry in gen]
+            finally:
+                await gen.aclose()
+
+            self.assertEqual(set(rest), {"cat-2.xml"})

--- a/il_supermarket_scarper/engines/tests/test_scrape_streaming.py
+++ b/il_supermarket_scarper/engines/tests/test_scrape_streaming.py
@@ -70,3 +70,79 @@ class TestScrapeStreaming(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(second.file_name, "slow.xml")
             finally:
                 await gen.aclose()
+
+    async def test_listing_error_still_yields_started_download(self):
+        """A listing failure after the first link must not cancel that download."""
+
+        class _FailAfterFirst(_DummyEngine):
+            async def collect_files_details_from_site(  # pylint: disable=too-many-arguments
+                self,
+                state,  # pylint: disable=unused-argument
+                limit=None,
+                files_types=None,
+                store_id=None,
+                when_date=None,
+                files_names_to_scrape=None,
+                filter_null=False,
+                filter_zero=False,
+                min_size=None,
+                max_size=None,
+                random_selection=False,
+            ):  # pylint: disable=unused-argument
+                yield ("http://x/1", "fast.xml")
+                raise RuntimeError("listing died")
+
+            async def process_file(self, file_details):
+                await asyncio.sleep(0.05)
+                return await super().process_file(file_details)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = _FailAfterFirst(tmp, asyncio.Event())
+            state = FilterState()
+            gen = scraper._scrape(state)  # pylint: disable=protected-access
+            try:
+                first = await asyncio.wait_for(anext(gen), timeout=1)
+                self.assertEqual(first.file_name, "fast.xml")
+                with self.assertRaises(StopAsyncIteration):
+                    await anext(gen)
+            finally:
+                await gen.aclose()
+
+    async def test_failed_download_does_not_drop_sibling(self):
+        """One process_file error must still yield other completed downloads."""
+
+        class _FailOne(_DummyEngine):
+            async def collect_files_details_from_site(  # pylint: disable=too-many-arguments
+                self,
+                state,  # pylint: disable=unused-argument
+                limit=None,
+                files_types=None,
+                store_id=None,
+                when_date=None,
+                files_names_to_scrape=None,
+                filter_null=False,
+                filter_zero=False,
+                min_size=None,
+                max_size=None,
+                random_selection=False,
+            ):  # pylint: disable=unused-argument
+                yield ("http://x/1", "good.xml")
+                yield ("http://x/2", "bad.xml")
+
+            async def process_file(self, file_details):
+                if file_details[1] == "bad.xml":
+                    raise RuntimeError("download failed")
+                return await super().process_file(file_details)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = _FailOne(tmp, asyncio.Event())
+            gen = scraper._scrape(FilterState())  # pylint: disable=protected-access
+            try:
+                results = [result async for result in gen]
+            finally:
+                await gen.aclose()
+
+        by_name = {result.file_name: result for result in results}
+        self.assertEqual(set(by_name), {"good.xml", "bad.xml"})
+        self.assertTrue(by_name["good.xml"].downloaded)
+        self.assertFalse(by_name["bad.xml"].downloaded)

--- a/il_supermarket_scarper/engines/tests/test_scrape_streaming.py
+++ b/il_supermarket_scarper/engines/tests/test_scrape_streaming.py
@@ -1,0 +1,72 @@
+"""Tests that Engine._scrape starts downloads before listing is exhausted."""
+
+import asyncio
+import tempfile
+import unittest
+
+from il_supermarket_scarper.engines.engine import Engine
+from il_supermarket_scarper.utils import DiskFileOutput, DumpFolderNames, ScrapingResult
+from il_supermarket_scarper.utils.state import FilterState
+
+
+class _DummyEngine(Engine):
+    """Engine whose listing can block after the first file."""
+
+    def __init__(self, storage_path, release_listing):
+        super().__init__(
+            chain=DumpFolderNames.SHUFERSAL,
+            chain_id="test",
+            max_threads=5,
+            file_output=DiskFileOutput(storage_path=storage_path),
+        )
+        self.release_listing = release_listing
+        self.downloads_started = []
+
+    async def collect_files_details_from_site(  # pylint: disable=too-many-arguments
+        self,
+        state,  # pylint: disable=unused-argument
+        limit=None,
+        files_types=None,
+        store_id=None,
+        when_date=None,
+        files_names_to_scrape=None,
+        filter_null=False,
+        filter_zero=False,
+        min_size=None,
+        max_size=None,
+        random_selection=False,
+    ):  # pylint: disable=unused-argument
+        yield ("http://x/1", "fast.xml")
+        await self.release_listing.wait()
+        yield ("http://x/2", "slow.xml")
+
+    async def process_file(self, file_details):
+        self.downloads_started.append(file_details[1])
+        return ScrapingResult(
+            file_name=file_details[1],
+            downloaded=True,
+            extract_succefully=True,
+        )
+
+
+class TestScrapeStreaming(unittest.IsolatedAsyncioTestCase):
+    """Verify downloads complete without waiting for remaining listing sites."""
+
+    async def test_first_download_completes_while_later_listing_is_blocked(self):
+        """A finished download must be yielded before more links are collected."""
+        with tempfile.TemporaryDirectory() as tmp:
+            release_listing = asyncio.Event()
+            scraper = _DummyEngine(tmp, release_listing)
+            state = FilterState()
+
+            gen = scraper._scrape(state)  # pylint: disable=protected-access
+            try:
+                first = await asyncio.wait_for(anext(gen), timeout=1)
+                self.assertEqual(first.file_name, "fast.xml")
+                self.assertEqual(scraper.downloads_started, ["fast.xml"])
+                self.assertFalse(release_listing.is_set())
+                release_listing.set()
+                second = await asyncio.wait_for(anext(gen), timeout=1)
+                self.assertEqual(second.file_name, "slow.xml")
+            finally:
+                await gen.aclose()

--- a/il_supermarket_scarper/engines/tests/test_web_streaming.py
+++ b/il_supermarket_scarper/engines/tests/test_web_streaming.py
@@ -68,3 +68,36 @@ class TestWebStreaming(unittest.IsolatedAsyncioTestCase):
                 await gen.aclose()
 
             self.assertEqual(rest, ["slow.xml"])
+
+    async def test_failed_site_does_not_drop_other_site(self):
+        """One listing URL error must not hide files already fetched from another."""
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = _DummyWeb(tmp)
+
+            async def fake_session(**request):
+                if "slow" in request["url"]:
+                    raise ConnectionError("slow site down")
+                response = MagicMock()
+                response.site = "fast"
+                return response
+
+            scraper.session_with_cookies_by_chain = fake_session
+            scraper.get_data_from_page = lambda req_res: [req_res.site]
+
+            async def fake_extract(all_trs):
+                for site in all_trs:
+                    yield FileEntry(
+                        name=f"{site}.xml", url=f"http://x/{site}", size=1
+                    )
+
+            scraper.extract_task_from_entry = fake_extract
+
+            names = []
+            gen = scraper.generate_all_files()
+            try:
+                async for entry in gen:
+                    names.append(entry.name)
+            finally:
+                await gen.aclose()
+
+            self.assertEqual(names, ["fast.xml"])

--- a/il_supermarket_scarper/engines/tests/test_web_streaming.py
+++ b/il_supermarket_scarper/engines/tests/test_web_streaming.py
@@ -1,0 +1,70 @@
+"""Tests that WebBase yields files from one site before other sites finish listing."""
+
+import asyncio
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+from il_supermarket_scarper.engines.web import WebBase
+from il_supermarket_scarper.utils import DiskFileOutput, DumpFolderNames, FileEntry
+
+
+class _DummyWeb(WebBase):
+    """Minimal WebBase with two listing URLs."""
+
+    def __init__(self, storage_path):
+        super().__init__(
+            chain=DumpFolderNames.SHUFERSAL,
+            chain_id="test",
+            url="https://example.test/",
+            max_threads=2,
+            file_output=DiskFileOutput(storage_path=storage_path),
+        )
+
+    async def get_request_url(
+        self, files_types=None, store_id=None, when_date=None
+    ):  # pylint: disable=unused-argument
+        yield {"url": "https://example.test/fast", "method": "GET"}
+        yield {"url": "https://example.test/slow", "method": "GET"}
+
+
+class TestWebStreaming(unittest.IsolatedAsyncioTestCase):
+    """Verify listing of multiple sites does not block the first site's files."""
+
+    async def test_yields_fast_site_before_slow_site_finishes(self):
+        """First site's files must appear while another listing URL is still in flight."""
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = _DummyWeb(tmp)
+            slow_started = asyncio.Event()
+            release_slow = asyncio.Event()
+
+            async def fake_session(**request):
+                if "slow" in request["url"]:
+                    slow_started.set()
+                    await release_slow.wait()
+                response = MagicMock()
+                response.site = "slow" if "slow" in request["url"] else "fast"
+                return response
+
+            scraper.session_with_cookies_by_chain = fake_session
+            scraper.get_data_from_page = lambda req_res: [req_res.site]
+
+            async def fake_extract(all_trs):
+                for site in all_trs:
+                    yield FileEntry(
+                        name=f"{site}.xml", url=f"http://x/{site}", size=1
+                    )
+
+            scraper.extract_task_from_entry = fake_extract
+
+            gen = scraper.generate_all_files()
+            try:
+                first = await asyncio.wait_for(anext(gen), timeout=1)
+                self.assertEqual(first.name, "fast.xml")
+                await asyncio.wait_for(slow_started.wait(), timeout=1)
+                release_slow.set()
+                rest = [entry.name async for entry in gen]
+            finally:
+                await gen.aclose()
+
+            self.assertEqual(rest, ["slow.xml"])

--- a/il_supermarket_scarper/engines/web.py
+++ b/il_supermarket_scarper/engines/web.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 from urllib.parse import parse_qs, urljoin, urlparse
 from bs4 import BeautifulSoup
@@ -112,19 +113,80 @@ class WebBase(Engine):
         ):
             yield item
 
-    async def generate_all_files(self, files_types=None, store_id=None, when_date=None):
-        """Generate all files from the web site."""
+    async def _fetch_files_from_request(self, request_info):
+        """Fetch one listing URL and return its FileEntry objects."""
+        req_res = await self.session_with_cookies_by_chain(**request_info)
+        current_trs = self.get_data_from_page(req_res)
+        entries = []
+        async for file_entry in self.extract_task_from_entry(current_trs):
+            entries.append(file_entry)
+        return entries
+
+    async def generate_all_files(  # pylint: disable=too-many-locals,too-many-branches
+        self, files_types=None, store_id=None, when_date=None
+    ):
+        """Generate files from every listing URL; yield as each site responds."""
         gen = self.get_request_url(
             files_types=files_types, store_id=store_id, when_date=when_date
         )
+        pending = set()
+        max_in_flight = max(1, self.max_threads)
+        request_exhausted = False
+        listing_done = object()
+        listing_task = None
+
+        async def next_request():
+            try:
+                return await anext(gen)
+            except StopAsyncIteration:
+                return listing_done
+
         try:
-            async for url in gen:
-                req_res = await self.session_with_cookies_by_chain(**url)
-                current_trs = self.get_data_from_page(req_res)
-                async for file_entry in self.extract_task_from_entry(current_trs):
-                    yield file_entry
+            while True:
+                if (
+                    not request_exhausted
+                    and listing_task is None
+                    and len(pending) < max_in_flight
+                ):
+                    listing_task = asyncio.create_task(next_request())
+
+                wait_for = set(pending)
+                if listing_task is not None:
+                    wait_for.add(listing_task)
+                if not wait_for:
+                    break
+
+                done, _pending = await asyncio.wait(
+                    wait_for, return_when=asyncio.FIRST_COMPLETED
+                )
+
+                if listing_task is not None and listing_task in done:
+                    request_info = listing_task.result()
+                    listing_task = None
+                    if request_info is listing_done:
+                        request_exhausted = True
+                    elif request_info:
+                        pending.add(
+                            asyncio.create_task(
+                                self._fetch_files_from_request(request_info)
+                            )
+                        )
+
+                for task in done:
+                    if task not in pending:
+                        continue
+                    pending.remove(task)
+                    for file_entry in task.result():
+                        yield file_entry
         finally:
+            if listing_task is not None:
+                listing_task.cancel()
+                await asyncio.gather(listing_task, return_exceptions=True)
             await gen.aclose()
+            for task in pending:
+                task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
 
     async def collect_files_details_from_site(  # pylint: disable=too-many-locals
         self,

--- a/il_supermarket_scarper/engines/web.py
+++ b/il_supermarket_scarper/engines/web.py
@@ -1,10 +1,10 @@
-import asyncio
 import re
 from urllib.parse import parse_qs, urljoin, urlparse
 from bs4 import BeautifulSoup
 from il_supermarket_scarper.utils import FileEntry, Logger
 from il_supermarket_scarper.utils import convert_nl_size_to_bytes, UnitSize
 from il_supermarket_scarper.utils.state import FilterState
+from il_supermarket_scarper.utils.async_work import stream_as_completed
 from .engine import Engine
 
 
@@ -122,71 +122,19 @@ class WebBase(Engine):
             entries.append(file_entry)
         return entries
 
-    async def generate_all_files(  # pylint: disable=too-many-locals,too-many-branches
-        self, files_types=None, store_id=None, when_date=None
-    ):
+    async def generate_all_files(self, files_types=None, store_id=None, when_date=None):
         """Generate files from every listing URL; yield as each site responds."""
         gen = self.get_request_url(
             files_types=files_types, store_id=store_id, when_date=when_date
         )
-        pending = set()
-        max_in_flight = max(1, self.max_threads)
-        request_exhausted = False
-        listing_done = object()
-        listing_task = None
-
-        async def next_request():
-            try:
-                return await anext(gen)
-            except StopAsyncIteration:
-                return listing_done
-
-        try:
-            while True:
-                if (
-                    not request_exhausted
-                    and listing_task is None
-                    and len(pending) < max_in_flight
-                ):
-                    listing_task = asyncio.create_task(next_request())
-
-                wait_for = set(pending)
-                if listing_task is not None:
-                    wait_for.add(listing_task)
-                if not wait_for:
-                    break
-
-                done, _pending = await asyncio.wait(
-                    wait_for, return_when=asyncio.FIRST_COMPLETED
-                )
-
-                if listing_task is not None and listing_task in done:
-                    request_info = listing_task.result()
-                    listing_task = None
-                    if request_info is listing_done:
-                        request_exhausted = True
-                    elif request_info:
-                        pending.add(
-                            asyncio.create_task(
-                                self._fetch_files_from_request(request_info)
-                            )
-                        )
-
-                for task in done:
-                    if task not in pending:
-                        continue
-                    pending.remove(task)
-                    for file_entry in task.result():
-                        yield file_entry
-        finally:
-            if listing_task is not None:
-                listing_task.cancel()
-                await asyncio.gather(listing_task, return_exceptions=True)
-            await gen.aclose()
-            for task in pending:
-                task.cancel()
-            if pending:
-                await asyncio.gather(*pending, return_exceptions=True)
+        async for file_entry in stream_as_completed(
+            gen,
+            self._fetch_files_from_request,
+            max(1, self.max_threads),
+            source_error_prefix="Error getting listing URL",
+            work_error_prefix="Error listing files from URL",
+        ):
+            yield file_entry
 
     async def collect_files_details_from_site(  # pylint: disable=too-many-locals
         self,

--- a/il_supermarket_scarper/scrappers/shufersal.py
+++ b/il_supermarket_scarper/scrappers/shufersal.py
@@ -1,4 +1,8 @@
+import re
 import urllib.parse
+from urllib.parse import urljoin, urlsplit, urlunsplit, parse_qs, urlencode
+
+from lxml import html as lxml_html
 
 from il_supermarket_scarper.engines import MultiPageWeb
 from il_supermarket_scarper.utils import DumpFolderNames, FileTypesFilters
@@ -12,14 +16,66 @@ class Shufersal(MultiPageWeb):
     def __init__(self, file_output=None, status_database=None):
         super().__init__(
             url="https://prices.shufersal.co.il/",
-            total_page_xpath="""//*[@id="gridContainer"]/table/tfoot/tr/td/a[6]/@href""",
+            total_page_xpath="""//*[@id="gridContainer"]/table/tfoot/tr/td/a/@href""",
             total_pages_pattern=r"[?&]page=([0-9]+)",
             chain=DumpFolderNames.SHUFERSAL,
             chain_id="7290027600007",
             file_output=file_output,
             status_database=status_database,
-            page_argument="&page",
+            page_argument="page",
         )
+
+    async def get_request_url(
+        self, files_types=None, store_id=None, when_date=None
+    ):  # pylint: disable=unused-argument
+        """Join listing roots without introducing a double slash."""
+        for arguments in self.build_params(
+            files_types=files_types, store_id=store_id, when_date=when_date
+        ):
+            yield {
+                "url": urljoin(self.url, arguments),
+                "method": "GET",
+            }
+
+    def get_number_of_pages(self, response):
+        """Use the highest page= in the footer, not a[6] (that is the >> skip)."""
+        html_body = lxml_html.fromstring(response.content)
+        hrefs = html_body.xpath(self.total_page_xpath)
+        page_nums = []
+        for href in hrefs:
+            match = re.search(self.total_pages_pattern, href or "")
+            if match:
+                page_nums.append(int(match.group(1)))
+        if not page_nums:
+            return None
+        return max(page_nums)
+
+    def _page_url(self, base_url, page_number):
+        """Attach page=N with ? or & as appropriate."""
+        if page_number <= 1:
+            return base_url
+        parsed = urlsplit(base_url)
+        query = parse_qs(parsed.query, keep_blank_values=True)
+        query["page"] = [str(page_number)]
+        return urlunsplit(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                parsed.path,
+                urlencode(query, doseq=True),
+                parsed.fragment,
+            )
+        )
+
+    def _pages_to_scrape(self, main_page_request, total_pages):
+        """Build page URLs from the listing root (page 1 is the root itself)."""
+        if total_pages is None:
+            return [main_page_request]
+        base_url = main_page_request["url"]
+        return [
+            {**main_page_request, "url": self._page_url(base_url, page_number)}
+            for page_number in range(1, total_pages + 1)
+        ]
 
     def get_file_types_id(self, files_types=None):
         """get the file type id"""
@@ -46,9 +102,13 @@ class Shufersal(MultiPageWeb):
 
         urls = []
         for file_type_id in file_type_ids:
+            if file_type_id == "0" and not store_id:
+                # Default "all" view matches the human portal at /, not catID=0.
+                urls.append("")
+                continue
             params = {"catID": file_type_id}
 
             if store_id:
                 params["storeId"] = store_id
-            urls.append(f"/FileObject/UpdateCategory?{urllib.parse.urlencode(params)}")
+            urls.append(f"FileObject/UpdateCategory?{urllib.parse.urlencode(params)}")
         return urls

--- a/il_supermarket_scarper/scrappers/tests/test_shufersal_pagination.py
+++ b/il_supermarket_scarper/scrappers/tests/test_shufersal_pagination.py
@@ -1,0 +1,92 @@
+"""Tests for Shufersal last-page detection and page URL joining."""
+
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+from il_supermarket_scarper.scrappers.shufersal import Shufersal
+from il_supermarket_scarper.utils import DiskFileOutput, FileTypesFilters
+
+
+def _pager_html(*hrefs):
+    links = "".join(f'<a href="{href}">{label}</a>' for href, label in hrefs)
+    return f"""
+    <div id="gridContainer">
+      <table>
+        <tbody><tr><td></td><td></td><td></td><td></td><td></td><td></td>
+        <td>file</td></tr></tbody>
+        <tfoot><tr><td>{links}</td></tr></tfoot>
+      </table>
+    </div>
+    """
+
+
+class TestShufersalPagination(unittest.TestCase):
+    """Verify Shufersal uses the highest footer page=, not a[6]/>> alone."""
+
+    def test_get_number_of_pages_uses_max_footer_page(self):
+        """>> jump (a[6]) must not win if a later numeric link is higher."""
+        html = _pager_html(
+            ("/?page=2", "2"),
+            ("/?page=3", "3"),
+            ("/?page=4", "4"),
+            ("/?page=5", "5"),
+            ("/?page=2", ">"),
+            ("/?page=86", ">>"),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = Shufersal(file_output=DiskFileOutput(storage_path=tmp))
+            response = MagicMock(content=html.encode())
+            self.assertEqual(scraper.get_number_of_pages(response), 86)
+
+    def test_pages_to_scrape_uses_query_page_on_root(self):
+        """Root listing page 2 is /?page=2, not /&page=2."""
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = Shufersal(file_output=DiskFileOutput(storage_path=tmp))
+            pages = scraper._pages_to_scrape(  # pylint: disable=protected-access
+                {"url": "https://prices.shufersal.co.il/", "method": "GET"},
+                3,
+            )
+            self.assertEqual(
+                [page["url"] for page in pages],
+                [
+                    "https://prices.shufersal.co.il/",
+                    "https://prices.shufersal.co.il/?page=2",
+                    "https://prices.shufersal.co.il/?page=3",
+                ],
+            )
+
+    def test_pages_to_scrape_appends_page_on_category_url(self):
+        """Category roots already have a query string; page uses &."""
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = Shufersal(file_output=DiskFileOutput(storage_path=tmp))
+            pages = scraper._pages_to_scrape(  # pylint: disable=protected-access
+                {
+                    "url": (
+                        "https://prices.shufersal.co.il/FileObject/"
+                        "UpdateCategory?catID=1"
+                    ),
+                    "method": "GET",
+                },
+                2,
+            )
+            self.assertEqual(
+                pages[1]["url"],
+                "https://prices.shufersal.co.il/FileObject/"
+                "UpdateCategory?catID=1&page=2",
+            )
+
+    def test_build_params_uses_root_for_all_types(self):
+        """Unfiltered listing should land on / like the human UI."""
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = Shufersal(file_output=DiskFileOutput(storage_path=tmp))
+            self.assertEqual(scraper.build_params(), [""])
+
+    def test_build_params_keeps_category_url_for_filtered_types(self):
+        """Typed filters should still use UpdateCategory endpoints."""
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = Shufersal(file_output=DiskFileOutput(storage_path=tmp))
+            params = scraper.build_params(
+                files_types=[FileTypesFilters.PRICE_FILE.name]
+            )
+            self.assertEqual(params, ["FileObject/UpdateCategory?catID=1"])

--- a/il_supermarket_scarper/utils/async_work.py
+++ b/il_supermarket_scarper/utils/async_work.py
@@ -1,0 +1,139 @@
+"""Bounded concurrent pull from an async source with overlapping work."""
+
+import asyncio
+from il_supermarket_scarper.utils.logger import Logger
+
+
+def _unpack_result(result):
+    """Yield a list's items, or the result itself when it is a single value."""
+    if result is None:
+        return
+    if isinstance(result, list):
+        yield from result
+        return
+    yield result
+
+
+def _default_error(prefix, error):
+    Logger.error(f"{prefix}: {error}")
+    Logger.error_execption(error)
+
+
+async def stream_as_completed(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    source,
+    start_work,
+    max_in_flight,
+    *,
+    accept_item=bool,
+    source_error_prefix="Error reading listing",
+    work_error_prefix="Error processing item",
+    on_source_error=None,
+    on_work_error=None,
+):
+    """Yield work results as they finish, without waiting to fill the pool.
+
+    Pulls items from ``source`` and runs ``start_work(item)`` with at most
+    ``max_in_flight`` tasks. Listing and work wait together so the first
+    completed result is not blocked on more source items.
+
+    A failed source pull stops further listing but still drains in-flight
+    work. A failed work task is logged and skipped so siblings in the same
+    wait batch are still yielded. More listing is scheduled before yielding
+    so the next site/page stays in flight while the consumer is busy.
+    """
+    handle_source_error = on_source_error or (
+        lambda error: _default_error(source_error_prefix, error)
+    )
+    handle_work_error = on_work_error or (
+        lambda error: _default_error(work_error_prefix, error)
+    )
+
+    listing_done = object()
+    pending = set()
+    source_exhausted = False
+    listing_task = None
+
+    async def next_source_item():
+        try:
+            return await anext(source)
+        except StopAsyncIteration:
+            return listing_done
+
+    def apply_source_item(source_item):
+        """Start work for a source item. Return True if listing is exhausted."""
+        if source_item is listing_done:
+            return True
+        if accept_item(source_item):
+            pending.add(asyncio.create_task(start_work(source_item)))
+        return False
+
+    async def refill():
+        """Start more listing/work if a source item is already available."""
+        nonlocal listing_task, source_exhausted
+        while not source_exhausted and len(pending) < max_in_flight:
+            if listing_task is None:
+                listing_task = asyncio.create_task(next_source_item())
+            await asyncio.sleep(0)
+            if not listing_task.done():
+                return
+            try:
+                source_item = listing_task.result()
+            except Exception as error:  # pylint: disable=broad-exception-caught
+                handle_source_error(error)
+                listing_task = None
+                source_exhausted = True
+                return
+            listing_task = None
+            source_exhausted = apply_source_item(source_item)
+
+    try:
+        while True:
+            await refill()
+
+            wait_for = set(pending)
+            if listing_task is not None:
+                wait_for.add(listing_task)
+            if not wait_for:
+                break
+
+            done, _pending = await asyncio.wait(
+                wait_for, return_when=asyncio.FIRST_COMPLETED
+            )
+
+            completed_items = []
+            for task in done:
+                if task not in pending:
+                    continue
+                pending.remove(task)
+                try:
+                    result = task.result()
+                except Exception as error:  # pylint: disable=broad-exception-caught
+                    handle_work_error(error)
+                    continue
+                completed_items.extend(_unpack_result(result))
+
+            if listing_task is not None and listing_task in done:
+                try:
+                    source_item = listing_task.result()
+                except Exception as error:  # pylint: disable=broad-exception-caught
+                    handle_source_error(error)
+                    listing_task = None
+                    source_exhausted = True
+                else:
+                    listing_task = None
+                    source_exhausted = apply_source_item(source_item)
+
+            # Keep listing ahead of the consumer before yielding.
+            await refill()
+
+            for item in completed_items:
+                yield item
+    finally:
+        if listing_task is not None:
+            listing_task.cancel()
+            await asyncio.gather(listing_task, return_exceptions=True)
+        await source.aclose()
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)

--- a/il_supermarket_scarper/utils/connection.py
+++ b/il_supermarket_scarper/utils/connection.py
@@ -8,6 +8,7 @@ import pickle
 import random
 import asyncio
 import fnmatch
+import threading
 from html import unescape
 from ftplib import FTP_TLS, error_perm
 
@@ -600,76 +601,119 @@ def url_retrieve_to_memory(url, timeout=30, chunk_size=8192):
     return file_buffer.getvalue()  # Return bytes
 
 
-async def collect_from_ftp(
+def _ftp_mlsd_size(facts):
+    """Parse MLSD size fact to int bytes, or None."""
+    size_str = facts.get("size")
+    try:
+        return int(size_str) if size_str else None
+    except (ValueError, TypeError):
+        return None
+
+
+def _include_ftp_mlsd_entry(name, facts, arg):
+    """Whether an MLSD entry should be yielded as a downloadable file."""
+    if facts.get("type") in ("dir", "cdir", "pdir"):
+        return False
+    return arg is None or fnmatch.fnmatch(name.lower(), arg.lower())
+
+
+async def collect_from_ftp(  # pylint: disable=too-many-locals,too-many-statements
     ftp_host, ftp_username, ftp_password, ftp_path, arg=None, timeout=60 * 5
 ):
-    """Async generator: yields (filename, size) tuples from the FTP server"""
+    """Yield FileEntry objects as the FTP directory listing arrives.
+
+    Listing runs in a worker thread and pushes names as MLSD/NLST lines
+    are read so Engine._scrape can start downloads before the directory
+    scan finishes. NLST fallback skips per-file SIZE (that extra RTT
+    cannot overlap the data connection); size filters already keep
+    entries with unknown size.
+    """
     Logger.info(
         f"Open async connection to FTP server with {ftp_host} "
         f", username: {ftp_username} , password: {ftp_password}"
     )
 
-    def _sync_ftp_list():  # pylint: disable=too-many-branches
-        """Synchronous FTP listing using FTP_TLS - returns a list"""
-        ftp = FTP_TLS(ftp_host, ftp_username, ftp_password, timeout=timeout)
-        ftp.trust_server_pasv_ipv4_address = True
+    loop = asyncio.get_running_loop()
+    results = asyncio.Queue()
+    sentinel = object()
+    cancelled = threading.Event()
+    ftp_box = {"ftp": None}
+
+    def emit(name, size):
+        if cancelled.is_set():
+            return
         try:
+            loop.call_soon_threadsafe(results.put_nowait, (name, size))
+        except RuntimeError:
+            # Event loop closed while the listing thread was still running.
+            pass
+
+    def _sync_ftp_list():  # pylint: disable=too-many-branches
+        """Push listing entries onto the async queue as they arrive."""
+        ftp = None
+        try:
+            ftp = FTP_TLS(ftp_host, ftp_username, ftp_password, timeout=timeout)
+            ftp.trust_server_pasv_ipv4_address = True
+            ftp_box["ftp"] = ftp
             ftp.cwd(ftp_path)
-
-            # Use MLSD for detailed file info if available, fall back to NLST + SIZE
-            files_with_sizes = []
             try:
-                # MLSD provides detailed info including size
-                all_entries = list(ftp.mlsd())
-
-                for name, facts in all_entries:
-                    if facts.get("type") == "file":
-                        size_str = facts.get("size")
-                        try:
-                            size = int(size_str) if size_str else None
-                        except (ValueError, TypeError):
-                            size = None
-
-                        # Apply glob filter if arg is provided (case-insensitive)
-                        if arg is None or fnmatch.fnmatch(name.lower(), arg.lower()):
-                            files_with_sizes.append((name, size))
-                    elif facts.get("type") in ["dir", "cdir", "pdir"]:
-                        # Skip directories
-                        pass
-                    else:
-                        # Unknown type - include if matches filter (case-insensitive)
-                        if arg is None or fnmatch.fnmatch(name.lower(), arg.lower()):
-                            files_with_sizes.append((name, None))
+                for name, facts in ftp.mlsd():
+                    if cancelled.is_set():
+                        return
+                    if _include_ftp_mlsd_entry(name, facts, arg):
+                        emit(name, _ftp_mlsd_size(facts))
             except error_perm:
-                # MLSD not supported, fall back to NLST
-                if arg:
-                    file_list = ftp.nlst(arg)
-                else:
-                    file_list = ftp.nlst()
+                # MLSD not supported: stream NLST lines. Do not SIZE each
+                # name here — SIZE uses the control connection and cannot
+                # run while the NLST data connection is open.
+                def on_nlst_line(line):
+                    if cancelled.is_set():
+                        raise error_perm("listing cancelled")
+                    name = line.strip()
+                    if name:
+                        emit(name, None)
 
-                # Get size for each file
-                for filename in file_list:
-                    try:
-                        ftp.voidcmd("TYPE I")  # Set binary mode
-                        size = ftp.size(filename)
-                    except error_perm:
-                        size = None
-                    files_with_sizes.append((filename, size))
-
-            return files_with_sizes
+                try:
+                    if arg:
+                        ftp.retrlines(f"NLST {arg}", on_nlst_line)
+                    else:
+                        ftp.retrlines("NLST", on_nlst_line)
+                except error_perm:
+                    if not cancelled.is_set():
+                        raise
         finally:
             try:
-                ftp.quit()
-            except Exception:  # pylint: disable=broad-exception-caught
+                loop.call_soon_threadsafe(results.put_nowait, sentinel)
+            except RuntimeError:
+                pass
+            if ftp is not None:
+                try:
+                    ftp.quit()
+                except Exception:  # pylint: disable=broad-exception-caught
+                    try:
+                        ftp.close()
+                    except Exception:  # pylint: disable=broad-exception-caught
+                        pass
+
+    producer = asyncio.create_task(asyncio.to_thread(_sync_ftp_list))
+    try:
+        while True:
+            item = await results.get()
+            if item is sentinel:
+                break
+            filename, size = item
+            yield FileEntry(name=filename, url=None, size=size)
+        await producer
+    finally:
+        cancelled.set()
+        ftp = ftp_box.get("ftp")
+        if ftp is not None:
+            try:
                 ftp.close()
-
-    # Run synchronous FTP operations in a thread pool and get the list
-    files_list = await asyncio.to_thread(_sync_ftp_list)
-
-    # Yield each file as an async generator
-
-    for filename, size in files_list:
-        yield FileEntry(name=filename, url=None, size=size)
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+        if not producer.done():
+            await asyncio.gather(producer, return_exceptions=True)
 
 
 def _sync_ftp_download_to_memory(

--- a/il_supermarket_scarper/utils/connection.py
+++ b/il_supermarket_scarper/utils/connection.py
@@ -32,6 +32,7 @@ from .logger import Logger
 from .file_entry import FileEntry
 from .retry import retry
 from .file_cache import file_cache
+from .lock_utils import lock_manager
 
 
 exceptions = (
@@ -284,17 +285,17 @@ def session_with_cookies(
 
     session = requests.Session()
     if chain_cookie_name:
-
-        try:
-            with open(chain_cookie_name, "rb") as f:
-                session.cookies.update(pickle.load(f))
-            # session.cookies.load()
-        except FileNotFoundError:
-            Logger.debug("Didn't find cookie file")
-        except Exception as e:
-            # There was an issue with reading the file.
-            os.remove(chain_cookie_name)
-            raise e
+        cookie_lock = lock_manager.get_lock(chain_cookie_name)
+        with cookie_lock:
+            try:
+                with open(chain_cookie_name, "rb") as f:
+                    session.cookies.update(pickle.load(f))
+            except FileNotFoundError:
+                Logger.debug("Didn't find cookie file")
+            except Exception as e:
+                # There was an issue with reading the file.
+                os.remove(chain_cookie_name)
+                raise e
 
     Logger.debug(
         f"On a new Session requesting url: method={method}, url={url}, body={body}"
@@ -317,9 +318,12 @@ def session_with_cookies(
             f" {response_content.status_code}"
         )
 
-    if chain_cookie_name and not os.path.exists(chain_cookie_name):
-        with open(chain_cookie_name, "wb") as f:
-            pickle.dump(session.cookies.get_dict(), f)
+    if chain_cookie_name:
+        cookie_lock = lock_manager.get_lock(chain_cookie_name)
+        with cookie_lock:
+            if not os.path.exists(chain_cookie_name):
+                with open(chain_cookie_name, "wb") as f:
+                    pickle.dump(session.cookies.get_dict(), f)
 
     return response_content
 
@@ -618,15 +622,21 @@ def _include_ftp_mlsd_entry(name, facts, arg):
 
 
 async def collect_from_ftp(  # pylint: disable=too-many-locals,too-many-statements
-    ftp_host, ftp_username, ftp_password, ftp_path, arg=None, timeout=60 * 5
+    ftp_host,
+    ftp_username,
+    ftp_password,
+    ftp_path,
+    arg=None,
+    timeout=60 * 5,
+    fetch_size=False,
 ):
     """Yield FileEntry objects as the FTP directory listing arrives.
 
     Listing runs in a worker thread and pushes names as MLSD/NLST lines
     are read so Engine._scrape can start downloads before the directory
-    scan finishes. NLST fallback skips per-file SIZE (that extra RTT
-    cannot overlap the data connection); size filters already keep
-    entries with unknown size.
+    scan finishes. NLST fallback streams names immediately. SIZE is only
+    issued after the NLST data connection closes, and only when
+    ``fetch_size`` is true (needed for min/max size filters).
     """
     Logger.info(
         f"Open async connection to FTP server with {ftp_host} "
@@ -663,14 +673,20 @@ async def collect_from_ftp(  # pylint: disable=too-many-locals,too-many-statemen
                     if _include_ftp_mlsd_entry(name, facts, arg):
                         emit(name, _ftp_mlsd_size(facts))
             except error_perm:
-                # MLSD not supported: stream NLST lines. Do not SIZE each
-                # name here — SIZE uses the control connection and cannot
-                # run while the NLST data connection is open.
+                # MLSD not supported. SIZE cannot run while the NLST data
+                # connection is open, so either emit names immediately or
+                # SIZE them after the listing finishes.
+                nlst_names = []
+
                 def on_nlst_line(line):
                     if cancelled.is_set():
                         raise error_perm("listing cancelled")
                     name = line.strip()
-                    if name:
+                    if not name:
+                        return
+                    if fetch_size:
+                        nlst_names.append(name)
+                    else:
                         emit(name, None)
 
                 try:
@@ -681,6 +697,17 @@ async def collect_from_ftp(  # pylint: disable=too-many-locals,too-many-statemen
                 except error_perm:
                     if not cancelled.is_set():
                         raise
+                if fetch_size:
+                    for name in nlst_names:
+                        if cancelled.is_set():
+                            return
+                        size = None
+                        try:
+                            ftp.voidcmd("TYPE I")
+                            size = ftp.size(name)
+                        except error_perm:
+                            size = None
+                        emit(name, size)
         finally:
             try:
                 loop.call_soon_threadsafe(results.put_nowait, sentinel)

--- a/il_supermarket_scarper/utils/lock_utils.py
+++ b/il_supermarket_scarper/utils/lock_utils.py
@@ -7,12 +7,14 @@ class LockManager:
 
     def __init__(self):
         self.locks = {}
+        self._guard = Lock()
 
     def get_lock(self, key):
         """Get or create a lock based on the string key."""
-        if key not in self.locks:
-            self.locks[key] = Lock()
-        return self.locks[key]
+        with self._guard:
+            if key not in self.locks:
+                self.locks[key] = Lock()
+            return self.locks[key]
 
 
 lock_manager = LockManager()

--- a/il_supermarket_scarper/utils/tests/test_async_work.py
+++ b/il_supermarket_scarper/utils/tests/test_async_work.py
@@ -1,0 +1,78 @@
+"""Tests for bounded concurrent listing/work overlap."""
+
+import asyncio
+import unittest
+
+from il_supermarket_scarper.utils.async_work import stream_as_completed
+
+
+class TestStreamAsCompleted(unittest.IsolatedAsyncioTestCase):
+    """Verify failed work or listing does not hide siblings that already finished."""
+
+    async def test_failed_work_does_not_drop_completed_sibling(self):
+        """A boom on one item must not prevent yielding other finished items."""
+
+        async def source():
+            yield "fast"
+            yield "fail"
+            yield "other"
+
+        async def work(item):
+            if item == "fail":
+                raise RuntimeError("boom")
+            return [item]
+
+        results = []
+        gen = stream_as_completed(source(), work, max_in_flight=3)
+        try:
+            async for item in gen:
+                results.append(item)
+        finally:
+            await gen.aclose()
+
+        self.assertEqual(set(results), {"fast", "other"})
+
+    async def test_source_error_still_yields_completed_work(self):
+        """A listing error after the first item must still yield that download."""
+
+        async def source():
+            yield "a"
+            raise RuntimeError("listing died")
+
+        async def work(item):
+            await asyncio.sleep(0.05)
+            return [item]
+
+        results = []
+        gen = stream_as_completed(source(), work, max_in_flight=2)
+        try:
+            async for item in gen:
+                results.append(item)
+        finally:
+            await gen.aclose()
+
+        self.assertEqual(results, ["a"])
+
+    async def test_yields_first_result_before_source_is_exhausted(self):
+        """Work on the first item must complete while later listing is blocked."""
+        release = asyncio.Event()
+
+        async def source():
+            yield "first"
+            await release.wait()
+            yield "second"
+
+        async def work(item):
+            return [item]
+
+        gen = stream_as_completed(source(), work, max_in_flight=2)
+        try:
+            first = await asyncio.wait_for(anext(gen), timeout=1)
+            self.assertEqual(first, "first")
+            self.assertFalse(release.is_set())
+            release.set()
+            rest = [item async for item in gen]
+        finally:
+            await gen.aclose()
+
+        self.assertEqual(rest, ["second"])

--- a/il_supermarket_scarper/utils/tests/test_cookie_session.py
+++ b/il_supermarket_scarper/utils/tests/test_cookie_session.py
@@ -1,0 +1,74 @@
+"""Tests for cookie pickle load/save under concurrent listing requests."""
+
+import os
+import pickle
+import tempfile
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from il_supermarket_scarper.utils.connection import session_with_cookies
+from il_supermarket_scarper.utils.lock_utils import LockManager
+
+
+class TestCookieSession(unittest.TestCase):
+    """Concurrent cookie file access must not corrupt the pickle."""
+
+    def test_get_lock_is_shared_under_concurrency(self):
+        """First-time lock creation must return one lock for the same key."""
+        manager = LockManager()
+        found = []
+        start = threading.Barrier(16)
+
+        def worker():
+            start.wait()
+            found.append(manager.get_lock("same-key"))
+
+        threads = [threading.Thread(target=worker) for _ in range(16)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(len({id(lock) for lock in found}), 1)
+
+    def test_concurrent_cookie_save_does_not_corrupt_file(self):
+        """Parallel session_with_cookies calls must read/write one valid pickle."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cookie_path = os.path.join(tmp, "chain_cookies.txt")
+            errors = []
+
+            response = MagicMock()
+            response.status_code = 200
+            response.text = "ok"
+
+            def run_request():
+                try:
+                    session_with_cookies(
+                        "http://example.test/listing",
+                        chain_cookie_name=cookie_path,
+                    )
+                except Exception as error:  # pylint: disable=broad-exception-caught
+                    errors.append(error)
+
+            session = MagicMock()
+            session.get.return_value = response
+            session.post.return_value = response
+            session.cookies.get_dict.return_value = {"sid": "1"}
+
+            with patch(
+                "il_supermarket_scarper.utils.connection.requests.Session",
+                return_value=session,
+            ):
+                threads = [
+                    threading.Thread(target=run_request) for _ in range(8)
+                ]
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join()
+
+            self.assertEqual(errors, [])
+            self.assertTrue(os.path.exists(cookie_path))
+            with open(cookie_path, "rb") as cookie_file:
+                self.assertEqual(pickle.load(cookie_file), {"sid": "1"})

--- a/il_supermarket_scarper/utils/tests/test_ftp_streaming.py
+++ b/il_supermarket_scarper/utils/tests/test_ftp_streaming.py
@@ -1,0 +1,162 @@
+"""Tests that FTP listing yields files before the directory scan finishes."""
+# pylint: disable=missing-function-docstring
+
+import asyncio
+import threading
+import unittest
+from unittest.mock import patch
+
+from ftplib import error_perm
+
+from il_supermarket_scarper.utils.connection import collect_from_ftp
+
+
+class _FakeMlsdFtp:
+    """FTP_TLS stand-in whose MLSD iterator can block mid-listing."""
+
+    def __init__(self, *args, **kwargs):  # pylint: disable=unused-argument
+        self.trust_server_pasv_ipv4_address = False
+        self.closed = False
+
+    def cwd(self, path):  # pylint: disable=unused-argument
+        """Change directory (no-op)."""
+        return None
+
+    def mlsd(self):
+        """Yield no entries unless a subclass overrides."""
+        return iter(())
+
+    def quit(self):
+        """Mark the fake connection closed."""
+        self.closed = True
+
+    def close(self):
+        """Mark the fake connection closed."""
+        self.closed = True
+
+
+class TestFtpStreaming(unittest.IsolatedAsyncioTestCase):
+    """Verify collect_from_ftp streams entries instead of buffering the listing."""
+
+    async def test_yields_before_mlsd_finishes(self):
+        """The first file must appear while a later MLSD entry is still blocked."""
+        started = threading.Event()
+        release = threading.Event()
+
+        class SlowMlsd(_FakeMlsdFtp):
+            """MLSD that blocks after the first file."""
+            def mlsd(self):
+                yield ("fast.xml", {"type": "file", "size": "10"})
+                started.set()
+                release.wait(timeout=5)
+                yield ("dir-a", {"type": "dir"})
+                yield ("slow.xml", {"type": "file", "size": "20"})
+
+        with patch(
+            "il_supermarket_scarper.utils.connection.FTP_TLS", SlowMlsd
+        ):
+            gen = collect_from_ftp("ftp.example", "user", "", "/")
+            try:
+                first = await asyncio.wait_for(anext(gen), timeout=1)
+                self.assertEqual(first.name, "fast.xml")
+                self.assertEqual(first.size, 10)
+                self.assertTrue(started.wait(timeout=1))
+                release.set()
+                rest = [entry.name async for entry in gen]
+            finally:
+                await gen.aclose()
+
+        self.assertEqual(rest, ["slow.xml"])
+
+    async def test_nlst_fallback_streams_without_size(self):
+        """NLST fallback should emit names as lines arrive, without SIZE."""
+        started = threading.Event()
+        release = threading.Event()
+        size_called = []
+
+        class NlstOnly(_FakeMlsdFtp):
+            """FTP that rejects MLSD and streams NLST lines."""
+            def mlsd(self):
+                raise error_perm("MLSD not supported")
+
+            def retrlines(self, cmd, callback):  # pylint: disable=unused-argument
+                callback("fast.xml")
+                started.set()
+                release.wait(timeout=5)
+                callback("slow.xml")
+
+            def size(self, name):
+                size_called.append(name)
+                return 1
+
+        with patch(
+            "il_supermarket_scarper.utils.connection.FTP_TLS", NlstOnly
+        ):
+            gen = collect_from_ftp("ftp.example", "user", "", "/")
+            try:
+                first = await asyncio.wait_for(anext(gen), timeout=1)
+                self.assertEqual(first.name, "fast.xml")
+                self.assertIsNone(first.size)
+                self.assertTrue(started.wait(timeout=1))
+                release.set()
+                rest = [entry.name async for entry in gen]
+            finally:
+                await gen.aclose()
+
+        self.assertEqual(rest, ["slow.xml"])
+        self.assertEqual(size_called, [])
+
+    async def test_aclose_stops_blocked_listing(self):
+        """Closing the generator should not wait for the rest of the listing."""
+        entered_slow = threading.Event()
+
+        class StuckMlsd(_FakeMlsdFtp):
+            """MLSD that stays blocked until close() is called."""
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self._stop = threading.Event()
+
+            def mlsd(self):
+                yield ("page1.xml", {"type": "file", "size": "1"})
+                entered_slow.set()
+                self._stop.wait(timeout=30)
+                if self.closed:
+                    return
+                yield ("page2.xml", {"type": "file", "size": "1"})
+
+            def quit(self):
+                self._stop.set()
+                super().quit()
+
+            def close(self):
+                self._stop.set()
+                super().close()
+
+        with patch(
+            "il_supermarket_scarper.utils.connection.FTP_TLS", StuckMlsd
+        ):
+            gen = collect_from_ftp("ftp.example", "user", "", "/")
+            try:
+                first = await asyncio.wait_for(anext(gen), timeout=1)
+                self.assertEqual(first.name, "page1.xml")
+                self.assertTrue(entered_slow.wait(timeout=1))
+            finally:
+                await asyncio.wait_for(gen.aclose(), timeout=2)
+
+    async def test_listing_error_propagates(self):
+        """A failed FTP login/cwd must not leave the generator blocked."""
+
+        class BoomFtp(_FakeMlsdFtp):
+            """FTP that fails on cwd."""
+            def cwd(self, path):  # pylint: disable=unused-argument
+                raise OSError("cwd failed")
+
+        with patch(
+            "il_supermarket_scarper.utils.connection.FTP_TLS", BoomFtp
+        ):
+            gen = collect_from_ftp("ftp.example", "user", "", "/")
+            try:
+                with self.assertRaises(OSError):
+                    await asyncio.wait_for(anext(gen), timeout=1)
+            finally:
+                await gen.aclose()

--- a/il_supermarket_scarper/utils/tests/test_ftp_streaming.py
+++ b/il_supermarket_scarper/utils/tests/test_ftp_streaming.py
@@ -160,3 +160,93 @@ class TestFtpStreaming(unittest.IsolatedAsyncioTestCase):
                     await asyncio.wait_for(anext(gen), timeout=1)
             finally:
                 await gen.aclose()
+
+    async def test_mlsd_glob_skips_non_matching_names(self):
+        """Client-side glob should drop MLSD names that do not match."""
+
+        class GlobMlsd(_FakeMlsdFtp):
+            """MLSD with mixed filenames."""
+
+            def mlsd(self):
+                yield ("keep.xml", {"type": "file", "size": "1"})
+                yield ("skip.txt", {"type": "file", "size": "2"})
+                yield ("also.xml.gz", {"type": "file", "size": "3"})
+
+        with patch(
+            "il_supermarket_scarper.utils.connection.FTP_TLS", GlobMlsd
+        ):
+            gen = collect_from_ftp("ftp.example", "user", "", "/", arg="*.xml")
+            try:
+                names = [entry.name async for entry in gen]
+            finally:
+                await gen.aclose()
+
+        self.assertEqual(names, ["keep.xml"])
+
+    async def test_nlst_fetch_size_runs_after_listing(self):
+        """When fetch_size is set, NLST names get SIZE after the data connection."""
+        size_called = []
+        retrlines_done = threading.Event()
+
+        class NlstSized(_FakeMlsdFtp):
+            """NLST fallback that records SIZE calls."""
+
+            def mlsd(self):
+                raise error_perm("MLSD not supported")
+
+            def retrlines(self, cmd, callback):  # pylint: disable=unused-argument
+                callback("a.xml")
+                callback("b.xml")
+                retrlines_done.set()
+
+            def voidcmd(self, cmd):  # pylint: disable=unused-argument
+                return None
+
+            def size(self, name):
+                if not retrlines_done.is_set():
+                    raise AssertionError("SIZE ran before NLST finished")
+                size_called.append(name)
+                return 10
+
+        with patch(
+            "il_supermarket_scarper.utils.connection.FTP_TLS", NlstSized
+        ):
+            gen = collect_from_ftp(
+                "ftp.example", "user", "", "/", fetch_size=True
+            )
+            try:
+                entries = [entry async for entry in gen]
+            finally:
+                await gen.aclose()
+
+        self.assertEqual([entry.name for entry in entries], ["a.xml", "b.xml"])
+        self.assertEqual([entry.size for entry in entries], [10, 10])
+        self.assertEqual(size_called, ["a.xml", "b.xml"])
+
+    async def test_nlst_passes_glob_to_server(self):
+        """NLST fallback should send the glob on the listing command."""
+        cmds = []
+
+        class NlstGlob(_FakeMlsdFtp):
+            """NLST that records the command and returns one name."""
+
+            def mlsd(self):
+                raise error_perm("MLSD not supported")
+
+            def retrlines(self, cmd, callback):
+                cmds.append(cmd)
+                callback("keep.xml")
+
+        with patch(
+            "il_supermarket_scarper.utils.connection.FTP_TLS", NlstGlob
+        ):
+            gen = collect_from_ftp(
+                "ftp.example", "user", "", "/", arg="*.xml"
+            )
+            try:
+                names = [entry.name async for entry in gen]
+            finally:
+                await gen.aclose()
+
+        self.assertEqual(cmds, ["NLST *.xml"])
+        self.assertEqual(names, ["keep.xml"])


### PR DESCRIPTION
## Summary
- Overlap HTTP, API, and multi-page listing with in-flight downloads instead of prefetching a full batch of links first.
- Stream FTP directory entries as MLSD/NLST lines arrive so Cerberus chains can start downloading before the full listing finishes.
- Add unit tests that the first file is yielded/downloaded while later sites or listing entries are still in flight.

## Test plan
- [ ] `python -m unittest il_supermarket_scarper.engines.tests.test_multipage_streaming il_supermarket_scarper.engines.tests.test_web_streaming il_supermarket_scarper.engines.tests.test_scrape_streaming il_supermarket_scarper.utils.tests.test_ftp_streaming -v`
- [ ] Smoke a WebBase/MultiPageWeb scraper and confirm downloads start before every listing URL/page is collected
- [ ] Smoke a Cerberus/FTP scraper and confirm the first file downloads while the directory listing is still running


Made with [Cursor](https://cursor.com)