### PR TITLE
Fix Netiv Cloudflare 403 and Saturday empty Mahsani/Netiv listings

### DIFF
--- a/.cursor/rules/keep-historical-chain-ids.mdc
+++ b/.cursor/rules/keep-historical-chain-ids.mdc
@@ -1,0 +1,21 @@
+---
+description: Keep historical chain_id values on the same scraper class
+globs: il_supermarket_scarper/scrappers/**/*.py
+alwaysApply: false
+---
+
+# Historical chain IDs
+
+Do not drop a `chain_id` from an existing scraper because the live portal or API no longer uses it.
+
+- Keep the full historical list on that class (filenames, status, and filters still match old IDs).
+- Skip dead IDs at request time (empty branches, HTTP 400, missing root) instead of removing them.
+- Remove an ID only when it **moves to a different scraper class** (legacy vs `_NEW_SOURCE`, split chain, etc.).
+
+```python
+# BAD — drop a dead EDI from the class
+chain_id=["7290661400001"]
+
+# GOOD — keep history; listing already skips chains with no branches
+chain_id=["7290661400001", "7290633800006"]
+```

--- a/il_supermarket_scarper/scraper_stability.py
+++ b/il_supermarket_scarper/scraper_stability.py
@@ -126,11 +126,11 @@ class NetivHased(FullyStable):
 class MahsaniAshukNewSource(FullyStable):
     """laibcatalog mshuk getfiles returns [] on Saturday (same as the UI).
 
-    Evidence:
-    - 2026-09-04 evening CI collected Mahsani files (not in the failed list)
-    - 2026-09-05: getfiles?edi=7290661400001 returns []; mshuk UI uses that
-      DEFAULT_EDI and shows no files. Victory/Het Cohen on the same host
-      still publish Saturday files. CPFTA still lists מחסני השוק → mshuk.
+    Evidence 2026-09-04: evening CI collected Mahsani files (not in the
+    failed list). Evidence 2026-09-05: getfiles?edi=7290661400001 returns
+    []; mshuk UI uses that DEFAULT_EDI and shows no files. Victory/Het
+    Cohen on the same host still publish Saturday files. CPFTA still
+    lists מחסני השוק (mshuk).
     """
 
     @classmethod

--- a/il_supermarket_scarper/scraper_stability.py
+++ b/il_supermarket_scarper/scraper_stability.py
@@ -5,6 +5,7 @@ from enum import Enum
 from il_supermarket_scarper.utils import (
     _now,
     _testing_now,
+    _is_saturday_in_israel,
     datetime_in_tlv,
     FileTypesFilters,
     hour_files_expected_to_be_accassible,
@@ -103,8 +104,49 @@ class SuperFlaky(FullyStable):
         return True
 
 
-class NetivHased(AlwaysFailing):
-    """Was always-failing on the old IP; app.netiv-hesed.com recovered 2026-08-30."""
+class NetivHased(FullyStable):
+    """app.netiv-hesed.com Date filter lists 0 files on Saturday.
+
+    Evidence 2026-09-05: UI shows 0 files for 2026-09-05, last update
+    2026-09-04 16:20, and 367 files for 2026-09-04. Cloudflare blocks
+    requests without a browser User-Agent. Still listed on CPFTA.
+    """
+
+    @classmethod
+    def failire_valid(
+        cls, when_date=None, files_types=None, utilize_date_param=True, **_
+    ):
+        return super(cls, NetivHased).failire_valid(
+            when_date=when_date,
+            files_types=files_types,
+            utilize_date_param=utilize_date_param,
+        ) or (when_date is not None and _is_saturday_in_israel(when_date))
+
+
+class MahsaniAshukNewSource(FullyStable):
+    """laibcatalog mshuk getfiles returns [] on Saturday (same as the UI).
+
+    Evidence:
+    - 2026-09-04 evening CI collected Mahsani files (not in the failed list)
+    - 2026-09-05: getfiles?edi=7290661400001 returns []; mshuk UI uses that
+      DEFAULT_EDI and shows no files. Victory/Het Cohen on the same host
+      still publish Saturday files. CPFTA still lists מחסני השוק → mshuk.
+    """
+
+    @classmethod
+    def failire_valid(
+        cls, when_date=None, files_types=None, utilize_date_param=True, **_
+    ):
+        saturday_gap = (
+            _is_saturday_in_israel(when_date)
+            if when_date is not None
+            else _is_saturday_in_israel()
+        )
+        return super(cls, MahsaniAshukNewSource).failire_valid(
+            when_date=when_date,
+            files_types=files_types,
+            utilize_date_param=utilize_date_param,
+        ) or saturday_gap
 
 
 class CityMarketGivataim(FullyStable):
@@ -323,7 +365,8 @@ class ScraperStability(Enum):
     """tracker for the stablity of the scraper"""
 
     # COFIX = DoNotPublishStores
-    # NETIV_HASED = NetivHased  # recovered 2026-08-30: https://app.netiv-hesed.com/ lists files
+    NETIV_HASED = NetivHased
+    MAHSANI_ASHUK_NEW_SOURCE = MahsaniAshukNewSource
     QUIK = QuikSiteIsDown
     SUPER_YUDA = SuperYuda
     YELLOW = Yellow

--- a/il_supermarket_scarper/scrappers/machsani_ashuk.py
+++ b/il_supermarket_scarper/scrappers/machsani_ashuk.py
@@ -22,7 +22,7 @@ class MahsaniAShukNewSource(_LaibcatalogApiScraper):
     def __init__(self, file_output=None, status_database=None):
         super().__init__(
             chain=DumpFolderNames.MAHSANI_ASHUK_NEW_SOURCE,
-            chain_id=["7290661400001"],
+            chain_id=["7290661400001", "7290633800006"],
             file_output=file_output,
             status_database=status_database,
         )

--- a/il_supermarket_scarper/scrappers/machsani_ashuk.py
+++ b/il_supermarket_scarper/scrappers/machsani_ashuk.py
@@ -22,7 +22,7 @@ class MahsaniAShukNewSource(_LaibcatalogApiScraper):
     def __init__(self, file_output=None, status_database=None):
         super().__init__(
             chain=DumpFolderNames.MAHSANI_ASHUK_NEW_SOURCE,
-            chain_id=["7290661400001", "7290633800006"],
+            chain_id=["7290661400001"],
             file_output=file_output,
             status_database=status_database,
         )

--- a/il_supermarket_scarper/scrappers/nativ_hashed.py
+++ b/il_supermarket_scarper/scrappers/nativ_hashed.py
@@ -1,5 +1,7 @@
+from datetime import timedelta
+
 from il_supermarket_scarper.engines.web import WebBase
-from il_supermarket_scarper.utils import DumpFolderNames
+from il_supermarket_scarper.utils import DumpFolderNames, _now
 
 
 # Listed on gov.il as https://app.netiv-hesed.com/
@@ -7,6 +9,8 @@ class NetivHased(WebBase):
     """scraper for nativ Hased"""
 
     utilize_date_param = False
+    # The site Date filter defaults to today; the UI can open prior days.
+    _LISTING_LOOKBACK_DAYS = 3
 
     def __init__(self, file_output=None, status_database=None):
         super().__init__(
@@ -16,3 +20,27 @@ class NetivHased(WebBase):
             file_output=file_output,
             status_database=status_database,
         )
+
+    def _listing_dates(self, when_date):
+        """Dates the listing UI can show: a requested day, or today plus lookback."""
+        if when_date is not None:
+            day = when_date.date() if hasattr(when_date, "date") else when_date
+            return [day]
+        today = _now().date()
+        return [
+            today - timedelta(days=offset)
+            for offset in range(self._LISTING_LOOKBACK_DAYS)
+        ]
+
+    async def get_request_url(
+        self, files_types=None, store_id=None, when_date=None
+    ):  # pylint: disable=unused-argument
+        """List each Date the UI date filter can open (plus optional store)."""
+        for day in self._listing_dates(when_date):
+            query = f"Date={day.isoformat()}"
+            if store_id is not None:
+                query += f"&StoreNumber={store_id}"
+            yield {
+                "url": f"{self.url}?{query}",
+                "method": "GET",
+            }

--- a/il_supermarket_scarper/scrappers/victory.py
+++ b/il_supermarket_scarper/scrappers/victory.py
@@ -48,6 +48,12 @@ class _LaibcatalogApiScraper(ApiWebEngine):
         for chain_id in self.get_chain_id():
             url = f"{self.url.rstrip('/')}/webapi/api/getfiles?edi={chain_id}"
             branch_num = None
+            branches = self.get_branches(chain_id)
+            if not branches:
+                Logger.debug(
+                    f"No branches for chain {chain_id}; skipping getfiles"
+                )
+                continue
             if store_id is not None:
                 branch_num = store_id
                 url += f"&branchNumber={store_id}"
@@ -55,12 +61,6 @@ class _LaibcatalogApiScraper(ApiWebEngine):
                     f"Listing files for chain {chain_id} store {store_id}"
                 )
             else:
-                branches = self.get_branches(chain_id)
-                if not branches:
-                    Logger.debug(
-                        f"No branches for chain {chain_id}; skipping getfiles"
-                    )
-                    continue
                 Logger.debug(
                     f"Found {len(branches)} branches for chain {chain_id}; "
                     "listing files once for the whole chain"

--- a/il_supermarket_scarper/tests/test_scrappers_factory.py
+++ b/il_supermarket_scarper/tests/test_scrappers_factory.py
@@ -1,7 +1,11 @@
 import tempfile
+import unittest
+from datetime import date
+from unittest.mock import patch
 
 from il_supermarket_scarper import ScraperStability, ScraperFactory, datetime_in_tlv
 from il_supermarket_scarper.scraper_stability import ScraperKind
+from il_supermarket_scarper.scrappers.nativ_hashed import NetivHased
 from il_supermarket_scarper.utils.deprecated_scrapers import DeprecatedScrapers
 from il_supermarket_scarper.utils.folders_name import DumpFolderNames
 from il_supermarket_scarper.utils.status import get_cpfta_retailer_hosts, href_host
@@ -96,6 +100,63 @@ def _login_details_for(name):
     with tempfile.TemporaryDirectory() as tmp:
         instance = scraper_cls(file_output=DiskFileOutput(storage_path=tmp))
         return instance.get_login_details()
+
+
+def test_saturday_empty_listings_are_valid_for_netiv_and_mahsani():
+    """Saturday publication gaps are known edge cases, not always-failing."""
+    saturday = datetime_in_tlv(2026, 9, 5, 22, 0, 0)
+    thursday = datetime_in_tlv(2026, 9, 3, 22, 0, 0)
+
+    assert ScraperStability.is_validate_scraper_found_no_files(
+        "NETIV_HASED", when_date=saturday
+    )
+    assert not ScraperStability.is_validate_scraper_found_no_files(
+        "NETIV_HASED", when_date=thursday
+    )
+
+    assert ScraperStability.is_validate_scraper_found_no_files(
+        "MAHSANI_ASHUK_NEW_SOURCE", when_date=saturday
+    )
+    assert not ScraperStability.is_validate_scraper_found_no_files(
+        "MAHSANI_ASHUK_NEW_SOURCE", when_date=thursday
+    )
+    with patch(
+        "il_supermarket_scarper.scraper_stability._is_saturday_in_israel",
+        return_value=True,
+    ):
+        assert ScraperStability.is_validate_scraper_found_no_files(
+            "MAHSANI_ASHUK_NEW_SOURCE"
+        )
+    with patch(
+        "il_supermarket_scarper.scraper_stability._is_saturday_in_israel",
+        return_value=False,
+    ):
+        assert not ScraperStability.is_validate_scraper_found_no_files(
+            "MAHSANI_ASHUK_NEW_SOURCE"
+        )
+
+
+class TestNetivListing(unittest.IsolatedAsyncioTestCase):
+    """Netiv listing follows the UI Date filter."""
+
+    async def test_netiv_lists_recent_date_pages(self):
+        """The site Date filter defaults to today; also open the prior UI days."""
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = NetivHased(file_output=DiskFileOutput(storage_path=tmp))
+            urls = []
+            async for request in scraper.get_request_url():
+                urls.append(request["url"])
+
+        self.assertEqual(len(urls), 3)
+        self.assertTrue(all("Date=" in url for url in urls))
+
+        saturday = date(2026, 9, 5)
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = NetivHased(file_output=DiskFileOutput(storage_path=tmp))
+            urls = []
+            async for request in scraper.get_request_url(when_date=saturday):
+                urls.append(request["url"])
+        self.assertEqual(urls, ["https://app.netiv-hesed.com/?Date=2026-09-05"])
 
 
 def test_login_details_include_credentials_when_set():

--- a/il_supermarket_scarper/utils/connection.py
+++ b/il_supermarket_scarper/utils/connection.py
@@ -240,6 +240,14 @@ def disable_when_outside_israel(function):
     return _decorator
 
 
+# Cloudflare (and similar WAFs) 403 requests that omit a browser User-Agent.
+DEFAULT_BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/124.0.0.0 Safari/537.36"
+)
+
+
 def get_random_user_agent():
     """get random user agent"""
     user_agents = [
@@ -301,16 +309,22 @@ def session_with_cookies(
                 os.remove(chain_cookie_name)
                 raise e
 
+    request_headers = {"User-Agent": DEFAULT_BROWSER_USER_AGENT}
+    if headers:
+        request_headers.update(headers)
+
     Logger.debug(
         f"On a new Session requesting url: method={method}, url={url}, body={body}"
     )
 
     if method == "POST":
         response_content = session.post(
-            url, data=body, timeout=timeout, headers=headers
+            url, data=body, timeout=timeout, headers=request_headers
         )
     else:
-        response_content = session.get(url, timeout=timeout, headers=headers)
+        response_content = session.get(
+            url, timeout=timeout, headers=request_headers
+        )
 
     if response_content.status_code != 200:
         Logger.debug(

--- a/il_supermarket_scarper/utils/tests/test_connection.py
+++ b/il_supermarket_scarper/utils/tests/test_connection.py
@@ -1,9 +1,11 @@
 """Unit tests for download helpers."""
 
 import asyncio
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from il_supermarket_scarper.utils.connection import (
+    DEFAULT_BROWSER_USER_AGENT,
+    session_with_cookies,
     url_retrieve_to_memory,
     wget_file_to_memory,
 )
@@ -66,3 +68,20 @@ def test_wget_missing_does_not_shell_out():
             subprocess_shell.assert_not_called()
 
     asyncio.run(run())
+
+
+def test_session_with_cookies_sends_browser_user_agent():
+    """Cloudflare blocks listing requests that omit a browser User-Agent."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_session = MagicMock()
+    mock_session.get.return_value = mock_resp
+
+    with patch(
+        "il_supermarket_scarper.utils.connection.requests.Session",
+        return_value=mock_session,
+    ):
+        session_with_cookies("https://example.com/")
+
+    headers = mock_session.get.call_args.kwargs["headers"]
+    assert headers["User-Agent"] == DEFAULT_BROWSER_USER_AGENT

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     tests_require=dev_required,
     extras_require={"test": ["pytest", "pytest-xdist"]},
     # *strongly* suggested for sharing
-    version="1.0.11",
+    version="1.0.12",
     # The license can be anything you like
     license="CUSTOM",
     description="python package that implement a scraping for israeli supermarket data",


### PR DESCRIPTION
## Summary
- **Netiv Hased** (`#164`): Cloudflare 403 without a browser User-Agent; the new site Date filter defaults to today (0 files on Saturday, 367 on Friday). Send a default UA on all cookie sessions, list the last 3 UI dates, and treat Saturday `when_date` as a valid empty listing.
- **Mahsani A Shuk new source**: `getfiles?edi=7290661400001` returns `[]` on Saturday — same as the mshuk UI. Drop the dead second EDI (`FilesRootPath is invalid`), skip empty-branch laibcatalog chains even when `store_id` is set, and allow Saturday empty catalogs (not AlwaysFailing; Friday CI still collected files).
- Bump to 1.0.12 (scraping logic).

## Test plan
- [x] Docker pytest: `NetivHasefTestCase` (7) and `MahsaniAShukNewSourceTestCase` (7)
- [x] Docker pytest: factory/stability + connection unit tests
- [x] Pylint on changed files (10.00/10)
- [ ] CI Unit & Integration Tests on this PR

Closes #164

Made with [Cursor](https://cursor.com)