### PR TITLE
hotfix: apply download limit after listing filters

### DIFF
--- a/.cursor/rules/apply-limit-after-filters.mdc
+++ b/.cursor/rules/apply-limit-after-filters.mdc
@@ -1,0 +1,26 @@
+---
+description: Apply download limit only after every listing filter
+globs: il_supermarket_scarper/engines/**/*.py
+alwaysApply: false
+---
+
+# Limit after all filters
+
+In `apply_limit`, never count `file_pass_limit` or stop at `limit` until **every** listing filter has run.
+
+Filters that must run first: already downloaded, unique, store id, file-name regex, file types, `when_date`.
+
+- `filter_file_types` matches types only. It must not increment the quota or `break` at `limit`.
+- `get_by_date` / `when_date` must run before the quota. Wolt lists many days in parallel; older names will otherwise burn `limit` and download nothing.
+- Apply `limit` in one place at the end of `apply_limit`, then aclose upstream listing.
+
+```python
+# BAD — quota inside type filter, date runs after
+intreable_ = self.filter_file_types(state, files, limit, files_types, ...)
+intreable_ = self.get_by_date(when_date, ...)
+
+# GOOD — type and date first; limit last
+intreable_ = self.filter_file_types(files, files_types, ...)
+intreable_ = self.get_by_date(when_date, ...)
+# then increment file_pass_limit / break at limit
+```

--- a/il_supermarket_scarper/engines/engine.py
+++ b/il_supermarket_scarper/engines/engine.py
@@ -307,7 +307,8 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
 
         This is a streaming version that processes files one at a time,
         applying various filters (already downloaded, unique, store ID,
-        file types, date) and enforcing the limit.
+        file name, file types, date) and enforcing the limit last so the
+        quota is not spent on files later filters would drop.
 
         Args:
             state (FilterState): State object tracking filter statistics.
@@ -372,15 +373,12 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
                 intreable_, file_name_regex, by_function=by_function
             )
 
-        # filter by file type
+        # filter by file type (no limit — date and other filters still need to run)
         if files_types:
             intreable_ = self.filter_file_types(
-                state,
                 intreable_,
-                limit,
                 files_types,
                 by_function,
-                random_selection=random_selection,
             )
 
         # Warning and filtering for random_selection
@@ -396,20 +394,16 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
                 f"when_date should be datetime or 'latest', got {when_date}"
             )
 
-        # If filter by limit without type
-        if limit and not files_types:
+        if limit is not None:
             assert limit > 0, "Limit must be greater than 0"
-            async for file in intreable_:
-                if state.file_pass_limit < limit:
-                    state.file_pass_limit += 1
-                    yield file
-                else:
-                    # Stop consuming; caller should aclose upstream listing gens
-                    # so parallel page/branch fetches can cancel.
-                    break
-        else:
-            async for file in intreable_:
-                yield file
+
+        async for file in intreable_:
+            if limit is not None and state.file_pass_limit >= limit:
+                # Stop consuming; caller should aclose upstream listing gens
+                # so parallel page/branch fetches can cancel.
+                break
+            state.file_pass_limit += 1
+            yield file
 
         # raise error if there was nothing to download.
         if state.file_pass_limit == 0:
@@ -420,31 +414,19 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
 
     async def filter_file_types(
         self,
-        state: FilterState,
         intreable: AsyncGenerator[FileEntry, None],
-        limit,
         files_types,
         by_function,
-        random_selection=False,  # pylint: disable=unused-argument
     ) -> AsyncGenerator[FileEntry, None]:
-        """filter the file types requested"""
+        """Yield files matching the requested types. Does not apply limit."""
 
         async for type_ in intreable:
-            # Check if the file matches any of the requested file types
             filename = by_function(type_)
-            matches = any(
+            if any(
                 FileTypesFilters.is_file_from_type(filename, file_type)
                 for file_type in files_types
-            )
-            if matches:
-                if limit is None:
-                    yield type_
-                elif state.file_pass_limit < limit:
-                    state.file_pass_limit += 1
-                    yield type_
-                else:
-                    break
-            # If file doesn't match the requested types, skip it (don't yield)
+            ):
+                yield type_
 
     def get_only_latest(self, by_function, intreable_):
         """get only the last version of the files"""

--- a/il_supermarket_scarper/engines/tests/test_engine.py
+++ b/il_supermarket_scarper/engines/tests/test_engine.py
@@ -3,17 +3,21 @@
 import re
 import tempfile
 import unittest
+from datetime import datetime
 
 from il_supermarket_scarper.engines.engine import Engine
+from il_supermarket_scarper.scrappers.wolt import Wolt
 from il_supermarket_scarper.scrappers_factory import ScraperFactory
 from il_supermarket_scarper.utils import (
     DiskFileOutput,
     DumpFolderNames,
     FileEntry,
+    FileTypesFilters,
     QueueFileOutput,
     InMemoryQueueHandler,
     get_output_folder,
 )
+from il_supermarket_scarper.utils.state import FilterState
 
 
 class TestEngineDeduplication(unittest.IsolatedAsyncioTestCase):
@@ -99,3 +103,45 @@ class TestEngineDeduplication(unittest.IsolatedAsyncioTestCase):
                 0,
                 f"{first_file} should not be downloaded again but got {second_results}",
             )
+
+
+class TestApplyLimitAfterFilters(unittest.IsolatedAsyncioTestCase):
+    """Limit must run after type/date filters, not before."""
+
+    async def test_limit_does_not_consume_quota_on_wrong_date(self):
+        """Older type-matching files must not burn limit before when_date."""
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = Wolt(file_output=DiskFileOutput(storage_path=tmp))
+
+            async def listed():
+                for name in (
+                    "PromoFull7290058249350-000-001-20260904-000001",
+                    "PromoFull7290058249350-000-002-20260905-000001",
+                    "PromoFull7290058249350-000-003-20260906-000001",
+                    "PromoFull7290058249350-000-004-20260907-000001",
+                    "PromoFull7290058249350-000-005-20260907-000002",
+                    "PromoFull7290058249350-000-006-20260907-000003",
+                    "Price7290058249350-000-007-20260907-000001",
+                ):
+                    yield FileEntry(name=name, url=f"http://example.test/{name}", size=1)
+
+            state = FilterState()
+            names = []
+            async for entry in scraper.apply_limit(
+                state,
+                listed(),
+                limit=3,
+                files_types=[FileTypesFilters.PROMO_FULL_FILE.name],
+                when_date=datetime(2026, 9, 7),
+            ):
+                names.append(entry.name)
+
+            self.assertEqual(
+                names,
+                [
+                    "PromoFull7290058249350-000-004-20260907-000001",
+                    "PromoFull7290058249350-000-005-20260907-000002",
+                    "PromoFull7290058249350-000-006-20260907-000003",
+                ],
+            )
+            self.assertEqual(state.file_pass_limit, 3)


### PR DESCRIPTION
## Summary
- Apply `limit` only after already-downloaded, store, name, type, and `when_date` filters so older daily listings cannot burn the quota.
- `filter_file_types` matches types only; it no longer increments `file_pass_limit`.
- Agent rule: keep the quota at the end of `apply_limit`.

Split from #166 (PR 1/6).

## Test plan
- [ ] `python -m unittest il_supermarket_scarper.engines.tests.test_engine.TestApplyLimitAfterFilters`
- [ ] CI test-suite

Made with [Cursor](https://cursor.com)