### PR TITLE
fix: allow empty City Market Shops store listings before noon

### DIFF
--- a/il_supermarket_scarper/scraper_stability.py
+++ b/il_supermarket_scarper/scraper_stability.py
@@ -229,6 +229,33 @@ class DoNotPublishStores(FullyStable):
         ) or cls.searching_for_store_full(files_types=files_types)
 
 
+class CityMarketShopsStores(FullyStable):
+    """City Market Shops store dumps publish around 11:00 IL.
+
+    Evidence 2026-09-08: CI at 10:59 IL listed 0 store files; the day's
+    ``StoresFull7290000000003`` dump is timestamped 11:00. Price/promo
+    scrapes on the same run succeeded. After noon IL the store file is listed.
+    """
+
+    @classmethod
+    def searching_for_store_before_noon(cls, files_types=None, **_):
+        """Store-only scrapes before the usual publish window may be empty."""
+        if files_types != [FileTypesFilters.STORE_FILE.name]:
+            return False
+        return _now().hour < hour_files_expected_to_be_accassible()
+
+    @classmethod
+    def failire_valid(
+        cls, when_date=None, files_types=None, utilize_date_param=True, **_
+    ):
+        """return true if the parser is stble"""
+        return super(cls, CityMarketShopsStores).failire_valid(
+            when_date=when_date,
+            files_types=files_types,
+            utilize_date_param=utilize_date_param,
+        ) or cls.searching_for_store_before_noon(files_types=files_types)
+
+
 class SuperYuda(FullyStable):
     """Super Yuda is stablity"""
 
@@ -375,6 +402,7 @@ class ScraperStability(Enum):
     # # CITY_MARKET_GIVATAYIM = CityMarketGivataim
     # CITY_MARKET_KIRYATONO = CityMarketKiratOno
     # CITY_MARKET_KIRYATGAT = CityMarketKiratGat  # recovered 2026-08-30: bina portal lists files
+    CITY_MARKET_SHOPS = CityMarketShopsStores
     MESHMAT_YOSEF_1 = DoNotPublishPromo
     VICTORY = VictoryMovedToNewSource
     # YOHANANOF = DoNotPublishStores

--- a/il_supermarket_scarper/tests/test_scrappers_factory.py
+++ b/il_supermarket_scarper/tests/test_scrappers_factory.py
@@ -1,12 +1,13 @@
 import tempfile
 import unittest
-from datetime import date
+from datetime import date, datetime
 from unittest.mock import patch
 
 from il_supermarket_scarper import ScraperStability, ScraperFactory, datetime_in_tlv
 from il_supermarket_scarper.scraper_stability import ScraperKind
 from il_supermarket_scarper.scrappers.nativ_hashed import NetivHased
 from il_supermarket_scarper.utils.deprecated_scrapers import DeprecatedScrapers
+from il_supermarket_scarper.utils.file_types import FileTypesFilters
 from il_supermarket_scarper.utils.folders_name import DumpFolderNames
 from il_supermarket_scarper.utils.status import get_cpfta_retailer_hosts, href_host
 from il_supermarket_scarper.utils.file_output import DiskFileOutput
@@ -134,6 +135,24 @@ def test_saturday_empty_listings_are_valid_for_netiv_and_mahsani():
         assert not ScraperStability.is_validate_scraper_found_no_files(
             "MAHSANI_ASHUK_NEW_SOURCE"
         )
+
+
+def test_city_market_shops_store_empty_before_noon():
+    """Store dumps publish around 11:00 IL; empty listings before noon are valid."""
+    store = FileTypesFilters.only_store()
+    morning = datetime(2026, 9, 8, 10, 59)
+    afternoon = datetime(2026, 9, 8, 13, 0)
+    with patch("il_supermarket_scarper.scraper_stability._now", return_value=morning):
+        assert ScraperStability.is_validate_scraper_found_no_files(
+            "CITY_MARKET_SHOPS", files_types=store
+        )
+    with patch("il_supermarket_scarper.scraper_stability._now", return_value=afternoon):
+        assert not ScraperStability.is_validate_scraper_found_no_files(
+            "CITY_MARKET_SHOPS", files_types=store
+        )
+    assert not ScraperStability.is_validate_scraper_found_no_files(
+        "CITY_MARKET_SHOPS", files_types=FileTypesFilters.only_price()
+    )
 
 
 class TestNetivListing(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
- Store dumps publish around 11:00 IL; morning CI should not fail when that type is still missing.

Split from #166 (PR 2/6). Independent of the listing/save stack.

## Test plan
- [ ] `python -m unittest il_supermarket_scarper.tests.test_scrappers_factory`
- [ ] CI test-suite

Made with [Cursor](https://cursor.com)