### PR TITLE
fix: skip verified listings by hash; keep duplicate FileNm

### DIFF
--- a/.cursor/rules/apply-limit-after-filters.mdc
+++ b/.cursor/rules/apply-limit-after-filters.mdc
@@ -8,7 +8,8 @@ alwaysApply: false
 
 In `apply_limit`, never count `file_pass_limit` or stop at `limit` until **every** listing filter has run.
 
-Filters that must run first: already downloaded, unique, store id, file-name regex, file types, `when_date`.
+Filters that must run first: already downloaded, store id, file-name regex, file types, `when_date`.
+Do not drop duplicate listing names in `apply_limit`. The same FileNm can appear twice; `FileOutput` keeps the original path and records a hash mismatch on status when sha256 differs.
 
 - `filter_file_types` matches types only. It must not increment the quota or `break` at `limit`.
 - `get_by_date` / `when_date` must run before the quota. Wolt lists many days in parallel; older names will otherwise burn `limit` and download nothing.

--- a/il_supermarket_scarper/engines/api_web.py
+++ b/il_supermarket_scarper/engines/api_web.py
@@ -72,34 +72,10 @@ class ApiWebEngine(WebBase):
             Logger.error(f"Failed to get data from {request_info['url']}: {e}")
             return []
 
-    @staticmethod
-    def _entry_filename(entry):
-        """Best-effort filename key for streaming dedupe."""
-        if not isinstance(entry, dict):
-            return None
-        return entry.get("fileName") or entry.get("filename") or entry.get("name")
-
-    def _dedupe_streaming_entries(self, entries, seen_names):
-        """Drop duplicate API filenames; keep non-dict entries as-is."""
-        deduped = []
-        for entry in entries:
-            filename = self._entry_filename(entry)
-            if not filename:
-                if not isinstance(entry, dict):
-                    deduped.append(entry)
-                continue
-            if filename in seen_names:
-                continue
-            seen_names.add(filename)
-            deduped.append(entry)
-        return deduped
-
-    def _filter_streamed_entries(self, entries, files_types, seen_names):
-        """Apply optional type filter and streaming dedupe to one batch."""
+    def _filter_streamed_entries(self, entries, files_types):
+        """Apply optional type filter to one listing batch."""
         if hasattr(self, "apply_filter_by_type"):
             entries = self.apply_filter_by_type(entries, files_types)
-        if hasattr(self, "dedupe_api_entries"):
-            entries = self._dedupe_streaming_entries(entries, seen_names)
         return entries
 
     async def extract_task_from_entry(self, all_trs):
@@ -125,13 +101,11 @@ class ApiWebEngine(WebBase):
         requests_to_make = self.get_request_url(
             files_types=files_types, store_id=store_id, when_date=when_date
         )
-        seen_names = set()
-
         async def fetch_files(request_info):
             raw = await asyncio.to_thread(
                 self._fetch_entries_for_request, request_info
             )
-            entries = self._filter_streamed_entries(raw, files_types, seen_names)
+            entries = self._filter_streamed_entries(raw, files_types)
             extracted = []
             async for file_entry in self.extract_task_from_entry(entries):
                 extracted.append(file_entry)
@@ -192,6 +166,6 @@ class ApiWebEngine(WebBase):
                 file_name_regex=file_name_regex,
                 random_selection=random_selection,
             ):
-                yield entry.url, entry.name
+                yield entry
         finally:
             await listing.aclose()

--- a/il_supermarket_scarper/engines/cerberus.py
+++ b/il_supermarket_scarper/engines/cerberus.py
@@ -45,23 +45,21 @@ class Cerberus(Engine):
         self.ftp_session = False
 
     async def process_file(self, file_details):
-        """Process a single file from Cerberus. file_details is file_name string."""
-        file_name = file_details
+        """Process a single listing FileEntry from Cerberus."""
+        entry = file_details
 
-        # Register that we've collected this file's details
         self.register_collected_file(
-            file_name_collected_from_site=file_name[0],
+            file_name_collected_from_site=entry.name,
             link_collected_from_site=None,
         )
 
-        # Process file from FTP - persist_from_ftp yields a ScrapingResult
-        async for result in self.persist_from_ftp(file_name[0]):
+        async for result in self.persist_from_ftp(entry):
             return result
 
-        # Should not reach here, but return error result if we do
         return ScrapingResult(
-            file_name=file_name[0],
+            file_entry=entry,
             downloaded=False,
+            save_decision=None,
             extract_succefully=False,
             error="No result from persist_from_ftp",
             restart_and_retry=False,
@@ -172,20 +170,22 @@ class Cerberus(Engine):
                 file_name_regex=file_name_regex,
                 by_function=lambda x: x.name,
             ):
-                yield entry.name, entry.url
+                yield entry
 
-    async def persist_from_ftp(self, file_name):
+    async def persist_from_ftp(self, entry):
         """download file to memory and extract it.
 
         Re-downloads a few times on extract failure (truncated transfer). If the
         FTP SIZE matched and extract still fails, mark ``source_corrupt`` —
         the remote file itself is bad, not our fetch path.
         """
+        file_name = entry.name
         downloaded = False
         extract_succefully = False
         restart_and_retry = False
         source_corrupt = False
         error = None
+        result = None
         max_attempts = 3
         try:
             ext = file_name.split(".")[-1] if "." in file_name else ""
@@ -247,9 +247,11 @@ class Cerberus(Engine):
             restart_and_retry = True
 
         yield ScrapingResult(
-            file_name=file_name,
+            file_entry=entry,
             downloaded=downloaded,
+            save_decision=None if result is None else result["save_decision"],
             extract_succefully=extract_succefully,
+            content_sha256=None if result is None else result["content_sha256"],
             restart_and_retry=restart_and_retry,
             error=error,
             source_corrupt=source_corrupt,

--- a/il_supermarket_scarper/engines/engine.py
+++ b/il_supermarket_scarper/engines/engine.py
@@ -306,9 +306,11 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
         Apply filtering and limiting to a stream of files.
 
         This is a streaming version that processes files one at a time,
-        applying various filters (already downloaded, unique, store ID,
+        applying various filters (already downloaded, store ID,
         file name, file types, date) and enforcing the limit last so the
-        quota is not spent on files later filters would drop.
+        quota is not spent on files later filters would drop. Duplicate
+        listing names are kept; FileOutput keeps the same path and
+        records a hash mismatch on status when sha256 differs.
 
         Args:
             state (FilterState): State object tracking filter statistics.
@@ -335,7 +337,7 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
             are considered for selection.
         """
 
-        # Stream one file at a time; unique() and date filters are online.
+        # Stream one file at a time; date filters are online.
         async def stream_to_list(
             state: FilterState, intreable: AsyncGenerator[FileEntry, None]
         ) -> AsyncGenerator[FileEntry, None]:
@@ -358,9 +360,6 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
             files_list,
             by_function=by_function,
         )
-
-        # filter unique links
-        intreable_ = self.unique(state, intreable_, by_function=by_function)
 
         # filter by store id
         if store_id:
@@ -489,15 +488,6 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
                 continue
 
         return groups_value
-
-    @classmethod
-    async def unique(cls, state: FilterState, iterable, by_function=lambda x: x):
-        """Returns the type of the file."""
-        async for item in iterable:
-            k = by_function(item)
-            if k not in state.unique_seen:
-                state.unique_seen.add(k)
-                yield item
 
     async def session_with_cookies_by_chain(
         self, url, method="GET", body=None, timeout=15, headers=None
@@ -643,6 +633,8 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
 
     def _extract_file_name(self, file_details):
         """Extract file name from file details for error reporting."""
+        if isinstance(file_details, FileEntry):
+            return file_details.name
         if isinstance(file_details, str):
             return file_details
         if isinstance(file_details, tuple) and len(file_details) > 1:
@@ -678,8 +670,9 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
                     file_name = self._extract_file_name(file_details)
                     self.register_download_fail(e, file_name)
                     return ScrapingResult(
-                        file_name=file_name,
+                        file_entry=file_details,
                         downloaded=False,
+                        save_decision=None,
                         extract_succefully=False,
                         error=str(e),
                         restart_and_retry=False,
@@ -775,14 +768,16 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
                 raise
             return await self._wget_file_to_memory(file_link, timeout)
 
-    async def save_and_extract(self, arg):  # pylint: disable=too-many-locals
+    async def save_and_extract(  # pylint: disable=too-many-locals
+        self, entry: FileEntry
+    ):
         """download file and extract it (in-memory)
 
         Re-downloads a few times on extract failure. If extract still fails
         after full downloads, mark ``source_corrupt`` (remote file is bad).
         """
 
-        file_link, file_name = arg
+        file_link, file_name = entry.url, entry.name
         Logger.debug(f"Processing {file_link} (in-memory)")
 
         downloaded = False
@@ -791,6 +786,7 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
         source_corrupt = False
         extract_succefully = False
         max_attempts = 3
+        result = None
 
         try:
             # Determine file name with extension (case-insensitive check)
@@ -825,9 +821,11 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
                 error = result.get("error")
                 if extract_succefully:
                     return ScrapingResult(
-                        file_name=file_name,
+                        file_entry=entry,
                         downloaded=downloaded,
+                        save_decision=result["save_decision"],
                         extract_succefully=True,
+                        content_sha256=result["content_sha256"],
                         error=None,
                         restart_and_retry=False,
                         source_corrupt=False,
@@ -846,9 +844,11 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
                     Logger.error(error)
 
             return ScrapingResult(
-                file_name=file_name,
+                file_entry=entry,
                 downloaded=downloaded,
+                save_decision=result["save_decision"],
                 extract_succefully=False,
+                content_sha256=result["content_sha256"],
                 error=error,
                 restart_and_retry=False,
                 source_corrupt=source_corrupt,
@@ -865,9 +865,11 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
             error = str(exception)
 
         return ScrapingResult(
-            file_name=file_name,
+            file_entry=entry,
             downloaded=downloaded,
+            save_decision=None if result is None else result["save_decision"],
             extract_succefully=False,
+            content_sha256=None if result is None else result["content_sha256"],
             error=error,
             restart_and_retry=restart_and_retry,
             source_corrupt=source_corrupt,

--- a/il_supermarket_scarper/engines/multipage_web.py
+++ b/il_supermarket_scarper/engines/multipage_web.py
@@ -266,7 +266,7 @@ class MultiPageWeb(WebBase):
             )
 
             async for entry in limited_files:
-                yield entry.url, entry.name
+                yield entry
         finally:
             await listing.aclose()
 

--- a/il_supermarket_scarper/engines/tests/test_engine.py
+++ b/il_supermarket_scarper/engines/tests/test_engine.py
@@ -17,6 +17,8 @@ from il_supermarket_scarper.utils import (
     InMemoryQueueHandler,
     get_output_folder,
 )
+from il_supermarket_scarper.utils.databases import JsonDataBase
+from il_supermarket_scarper.utils.scraper_status import ScraperStatus
 from il_supermarket_scarper.utils.state import FilterState
 
 
@@ -108,10 +110,17 @@ class TestEngineDeduplication(unittest.IsolatedAsyncioTestCase):
 class TestApplyLimitAfterFilters(unittest.IsolatedAsyncioTestCase):
     """Limit must run after type/date filters, not before."""
 
+    def _wolt(self, tmp):
+        """Wolt with status DB inside ``tmp`` so tests do not share verified names."""
+        return Wolt(
+            file_output=DiskFileOutput(storage_path=tmp),
+            status_database=JsonDataBase("wolt_apply_limit", tmp),
+        )
+
     async def test_limit_does_not_consume_quota_on_wrong_date(self):
         """Older type-matching files must not burn limit before when_date."""
         with tempfile.TemporaryDirectory() as tmp:
-            scraper = Wolt(file_output=DiskFileOutput(storage_path=tmp))
+            scraper = self._wolt(tmp)
 
             async def listed():
                 for name in (
@@ -145,3 +154,83 @@ class TestApplyLimitAfterFilters(unittest.IsolatedAsyncioTestCase):
                 ],
             )
             self.assertEqual(state.file_pass_limit, 3)
+
+    async def test_duplicate_listing_names_are_kept(self):
+        """The same FileNm listed twice must both pass apply_limit."""
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = self._wolt(tmp)
+            name = "PromoFull7290058249350-000-004-20260907-000001"
+
+            async def listed():
+                yield FileEntry(name=name, url="http://example.test/a", size=1)
+                yield FileEntry(name=name, url="http://example.test/b", size=1)
+
+            state = FilterState()
+            kept = []
+            async for entry in scraper.apply_limit(state, listed(), limit=2):
+                kept.append((entry.name, entry.url))
+
+            self.assertEqual(
+                kept,
+                [
+                    (name, "http://example.test/a"),
+                    (name, "http://example.test/b"),
+                ],
+            )
+            self.assertEqual(state.file_pass_limit, 2)
+
+    async def test_verified_listing_hash_skips_only_that_listing(self):
+        """Same FileNm with a different url/size still downloads."""
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = self._wolt(tmp)
+            name = "PromoFull7290058249350-000-004-20260907-000001"
+            first = FileEntry(name=name, url="http://example.test/a", size=1)
+            second = FileEntry(name=name, url="http://example.test/b", size=1)
+            scraper.database.insert_document(
+                ScraperStatus.VERIFIED_DOWNLOADS,
+                {
+                    "file_name": name,
+                    "listing_hash": first.listing_hash(),
+                    "task_id": "previous",
+                },
+            )
+
+            async def listed():
+                yield first
+                yield second
+
+            state = FilterState()
+            kept = []
+            async for entry in scraper.apply_limit(state, listed(), limit=2):
+                kept.append((entry.name, entry.url))
+
+            self.assertEqual(kept, [(name, "http://example.test/b")])
+
+    async def test_identical_verified_listing_is_skipped(self):
+        """The same FileEntry hash is not downloaded again."""
+        with tempfile.TemporaryDirectory() as tmp:
+            scraper = self._wolt(tmp)
+            entry = FileEntry(
+                name="PromoFull7290058249350-000-004-20260907-000001",
+                url="http://example.test/a",
+                size=1,
+            )
+            scraper.database.insert_document(
+                ScraperStatus.VERIFIED_DOWNLOADS,
+                {
+                    "file_name": entry.name,
+                    "listing_hash": entry.listing_hash(),
+                    "task_id": "previous",
+                },
+            )
+
+            async def listed():
+                yield entry
+                yield entry
+
+            state = FilterState()
+            kept = []
+            async for item in scraper.apply_limit(state, listed(), limit=2):
+                kept.append(item)
+
+            self.assertEqual(kept, [])

--- a/il_supermarket_scarper/engines/tests/test_scrape_streaming.py
+++ b/il_supermarket_scarper/engines/tests/test_scrape_streaming.py
@@ -5,7 +5,12 @@ import tempfile
 import unittest
 
 from il_supermarket_scarper.engines.engine import Engine
-from il_supermarket_scarper.utils import DiskFileOutput, DumpFolderNames, ScrapingResult
+from il_supermarket_scarper.utils import (
+    DiskFileOutput,
+    DumpFolderNames,
+    FileEntry,
+    ScrapingResult,
+)
 from il_supermarket_scarper.utils.state import FilterState
 
 
@@ -36,15 +41,16 @@ class _DummyEngine(Engine):
         max_size=None,
         random_selection=False,
     ):  # pylint: disable=unused-argument
-        yield ("http://x/1", "fast.xml")
+        yield FileEntry(name="fast.xml", url="http://x/1", size=1)
         await self.release_listing.wait()
-        yield ("http://x/2", "slow.xml")
+        yield FileEntry(name="slow.xml", url="http://x/2", size=1)
 
     async def process_file(self, file_details):
-        self.downloads_started.append(file_details[1])
+        self.downloads_started.append(file_details.name)
         return ScrapingResult(
-            file_name=file_details[1],
+            file_entry=file_details,
             downloaded=True,
+            save_decision=None,
             extract_succefully=True,
         )
 
@@ -89,7 +95,7 @@ class TestScrapeStreaming(unittest.IsolatedAsyncioTestCase):
                 max_size=None,
                 random_selection=False,
             ):  # pylint: disable=unused-argument
-                yield ("http://x/1", "fast.xml")
+                yield FileEntry(name="fast.xml", url="http://x/1", size=1)
                 raise RuntimeError("listing died")
 
             async def process_file(self, file_details):
@@ -126,11 +132,11 @@ class TestScrapeStreaming(unittest.IsolatedAsyncioTestCase):
                 max_size=None,
                 random_selection=False,
             ):  # pylint: disable=unused-argument
-                yield ("http://x/1", "good.xml")
-                yield ("http://x/2", "bad.xml")
+                yield FileEntry(name="good.xml", url="http://x/1", size=1)
+                yield FileEntry(name="bad.xml", url="http://x/2", size=1)
 
             async def process_file(self, file_details):
-                if file_details[1] == "bad.xml":
+                if file_details.name == "bad.xml":
                     raise RuntimeError("download failed")
                 return await super().process_file(file_details)
 

--- a/il_supermarket_scarper/engines/web.py
+++ b/il_supermarket_scarper/engines/web.py
@@ -186,18 +186,15 @@ class WebBase(Engine):
             file_name_regex=file_name_regex,
             random_selection=random_selection,
         ):
-            yield entry.url, entry.name
+            yield entry
 
     async def process_file(self, file_details):
-        """Process a single file from WebBase. file_details is (download_url, file_name) tuple."""
-        download_url, file_name = file_details
+        """Process a single listing FileEntry from WebBase."""
+        entry = file_details
 
-        # Register that we've collected this file's details
         self.register_collected_file(
-            file_name_collected_from_site=file_name,
-            link_collected_from_site=download_url,
+            file_name_collected_from_site=entry.name,
+            link_collected_from_site=entry.url,
         )
 
-        # Download and extract the file
-        result = await self.save_and_extract((download_url, file_name))
-        return result
+        return await self.save_and_extract(entry)

--- a/il_supermarket_scarper/scrappers/victory.py
+++ b/il_supermarket_scarper/scrappers/victory.py
@@ -126,21 +126,6 @@ class _LaibcatalogApiScraper(ApiWebEngine):
             Logger.debug(f"Failed to parse file size '{size_str}': {e}")
             return 0
 
-    def dedupe_api_entries(self, all_entries):
-        """One getfiles response per branch repeats the same files; keep first only."""
-        seen = set()
-        out = []
-        for entry in all_entries:
-            if not isinstance(entry, dict):
-                out.append(entry)
-                continue
-            fn = entry.get("fileName") or entry.get("filename") or entry.get("name")
-            if not fn or fn in seen:
-                continue
-            seen.add(fn)
-            out.append(entry)
-        return out
-
     def apply_filter_by_type(self, entries, files_types=None):
         """Filter entries by file type"""
         if not files_types or files_types == FileTypesFilters.all_types():

--- a/il_supermarket_scarper/utils/databases/base.py
+++ b/il_supermarket_scarper/utils/databases/base.py
@@ -19,6 +19,10 @@ class AbstractDataBase(ABC):
     def already_downloaded(self, collection_name, query):
         """Check if a document is already downloaded based on a query."""
 
+    def find_document(self, collection_name, query):  # pylint: disable=unused-argument
+        """Return the first matching document, or None."""
+        return None
+
     @abstractmethod
     def get_last_modified(self):
         """Get the last modified timestamp when scraper last wrote to this database."""

--- a/il_supermarket_scarper/utils/databases/json_file.py
+++ b/il_supermarket_scarper/utils/databases/json_file.py
@@ -89,6 +89,10 @@ class JsonDataBase(AbstractDataBase):
 
     def already_downloaded(self, collection_name, query):
         """Find a document in a collection based on a query."""
+        return self.find_document(collection_name, query) is not None
+
+    def find_document(self, collection_name, query):
+        """Return the first matching document, or None."""
         file_path = self._get_database_file_path()
 
         if os.path.exists(file_path):
@@ -96,15 +100,13 @@ class JsonDataBase(AbstractDataBase):
                 try:
                     data = json.load(file)
 
-                    # Check if the collection exists
                     if collection_name in data:
-                        # Filter the documents in the collection based on the query
                         for document in data[collection_name]:
                             if all(item in document.items() for item in query.items()):
-                                return True
+                                return document
                 except json.JSONDecodeError:
                     Logger.warning(f"File {file_path} is corrupted.")
-        return False
+        return None
 
     def _update_last_modified(self):
         """Update the last modified timestamp to current time."""

--- a/il_supermarket_scarper/utils/databases/mongo.py
+++ b/il_supermarket_scarper/utils/databases/mongo.py
@@ -36,6 +36,10 @@ class MongoDataBase(AbstractDataBase):
 
     def already_downloaded(self, collection_name, query):
         """Find a document in a MongoDB collection."""
+        return self.find_document(collection_name, query) is not None
+
+    def find_document(self, collection_name, query):
+        """Return the first matching document, or None."""
         if self.store_db is None:
             self.create_connection()
         return self.store_db[collection_name].find_one(query)

--- a/il_supermarket_scarper/utils/file_entry.py
+++ b/il_supermarket_scarper/utils/file_entry.py
@@ -1,5 +1,6 @@
 """Data type for file entries flowing through the scraper pipeline."""
 
+import hashlib
 from typing import NamedTuple, Optional
 
 
@@ -14,3 +15,9 @@ class FileEntry(NamedTuple):
     name: str
     url: str
     size: Optional[int]
+
+    def listing_hash(self) -> str:
+        """Stable sha256 of listing identity (name, url, size)."""
+        size = "" if self.size is None else str(self.size)
+        payload = f"{self.name}\n{self.url}\n{size}".encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()

--- a/il_supermarket_scarper/utils/file_output.py
+++ b/il_supermarket_scarper/utils/file_output.py
@@ -1,16 +1,70 @@
 """Abstract file output interface for saving scraped files."""
 
 import asyncio
+import hashlib
 import multiprocessing
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import Any, Dict, AsyncGenerator, Optional, Tuple
 import os
 from .logger import Logger
 from .gzip_utils import extract_xml_from_gz_in_memory, is_compressed_content
 
 
+class SaveDecision(str, Enum):
+    """How FileOutput resolved a repeated file name."""
+
+    CREATED = "created"  # first time this name is stored
+    REWROTE_SAME = "rewrote_same"  # same name, same sha256; no write
+    HASH_MISMATCH = "hash_mismatch"  # same name, different sha256; keep file, status records hash
+
+
+def content_sha256(content: bytes) -> str:
+    """Hex digest of file bytes."""
+    return hashlib.sha256(content).hexdigest()
+
+
 class FileOutput(ABC):
     """Abstract base class for file output handlers."""
+
+    def __init__(self):
+        self._saved_digests: Dict[str, str] = {}
+        self._save_locks: Dict[str, asyncio.Lock] = {}
+        self._save_locks_guard = asyncio.Lock()
+
+    async def _lock_for_name(self, file_name: str) -> asyncio.Lock:
+        """Serialize saves that share an extracted file name."""
+        async with self._save_locks_guard:
+            lock = self._save_locks.get(file_name)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._save_locks[file_name] = lock
+            return lock
+
+    def resolve_save_name(
+        self, file_name: str, content: bytes
+    ) -> Tuple[str, SaveDecision, str]:
+        """Keep ``file_name``. Compare sha256 against this scrape's memory.
+
+        Same hash is a no-op. Different hash keeps the existing file and
+        returns ``HASH_MISMATCH`` so status can record the new digest.
+        Digest is stored only after a successful first write/send.
+        """
+        digest = content_sha256(content)
+        known = self._saved_digests.get(file_name)
+        if known is None:
+            return file_name, SaveDecision.CREATED, digest
+        if known == digest:
+            return file_name, SaveDecision.REWROTE_SAME, digest
+        Logger.warning(
+            f"{file_name} already stored with sha256={known}; "
+            f"downloaded sha256={digest}; keeping existing file"
+        )
+        return file_name, SaveDecision.HASH_MISMATCH, digest
+
+    def _remember_digest(self, file_name: str, digest: str) -> None:
+        """Record sha256 after a successful write or queue send."""
+        self._saved_digests[file_name] = digest
 
     @abstractmethod
     async def save_file(
@@ -94,6 +148,7 @@ class DiskFileOutput(FileOutput):
         self.storage_path = storage_path
         self.extract_gz = extract_gz
         os.makedirs(storage_path, exist_ok=True)
+        super().__init__()
 
     async def save_file(
         self,
@@ -106,6 +161,8 @@ class DiskFileOutput(FileOutput):
         saved = False
         extract_successfully = False
         error = None
+        digest = None
+        save_decision = None
 
         try:
             # Extract if it's compressed
@@ -117,23 +174,38 @@ class DiskFileOutput(FileOutput):
             if not extract_successfully:
                 error = extract_error
 
-            # Write file content to disk
-            file_save_path = os.path.join(self.storage_path, file_name)
-            await asyncio.to_thread(self._write_file, file_save_path, file_content)
+            lock = await self._lock_for_name(file_name)
+            async with lock:
+                file_name, save_decision, digest = self.resolve_save_name(
+                    file_name, file_content
+                )
+                file_save_path = os.path.join(self.storage_path, file_name)
+                if save_decision == SaveDecision.CREATED:
+                    await asyncio.to_thread(
+                        self._write_file, file_save_path, file_content
+                    )
+                    self._remember_digest(file_name, digest)
 
             saved = True
-            Logger.debug(f"Saved {file_link} to {file_save_path}")
+            Logger.debug(
+                f"Saved {file_link} to {file_save_path} sha256={digest} "
+                f"save_decision={save_decision}"
+            )
 
         except Exception as exception:  # pylint: disable=broad-except
             Logger.error(f"Error saving {file_link} to disk: {exception}")
             Logger.error_execption(exception)
             error = str(exception)
+            digest = None
+            save_decision = None
 
         return {
             "file_name": file_name,
             "saved": saved,
             "extract_successfully": extract_successfully,
             "error": error,
+            "content_sha256": digest,
+            "save_decision": save_decision,
             "metadata": metadata or {},
         }
 
@@ -180,6 +252,7 @@ class QueueFileOutput(FileOutput):
         self.storage_path = storage_path
         self.extract_gz = extract_gz
         os.makedirs(storage_path, exist_ok=True)
+        super().__init__()
 
     async def save_file(
         self,
@@ -192,6 +265,8 @@ class QueueFileOutput(FileOutput):
         saved = False
         extract_successfully = False
         error = None
+        digest = None
+        save_decision = None
 
         try:
             # Extract if it's compressed (detected by magic bytes)
@@ -202,29 +277,43 @@ class QueueFileOutput(FileOutput):
             )
             if not extract_successfully:
                 error = extract_error
-            # Send file to queue
             if extract_successfully:
-                message = {
-                    "file_name": file_name,
-                    "file_link": file_link,
-                    "file_content": file_content,
-                    "metadata": metadata or {},
-                }
-
-                await self.queue_handler.send(message)
+                lock = await self._lock_for_name(file_name)
+                async with lock:
+                    file_name, save_decision, digest = self.resolve_save_name(
+                        file_name, file_content
+                    )
+                    if save_decision == SaveDecision.CREATED:
+                        message = {
+                            "file_name": file_name,
+                            "file_link": file_link,
+                            "file_content": file_content,
+                            "content_sha256": digest,
+                            "save_decision": save_decision,
+                            "metadata": metadata or {},
+                        }
+                        await self.queue_handler.send(message)
+                        self._remember_digest(file_name, digest)
                 saved = True
-                Logger.debug(f"Sent {file_name} to queue")
+                Logger.debug(
+                    f"Queue {file_name} sha256={digest} "
+                    f"save_decision={save_decision}"
+                )
 
         except Exception as exception:  # pylint: disable=broad-except
             Logger.error(f"Error sending {file_link} to queue: {exception}")
             Logger.error_execption(exception)
             error = str(exception)
+            digest = None
+            save_decision = None
 
         return {
             "file_name": file_name,
             "saved": saved,
             "extract_successfully": extract_successfully,
             "error": error,
+            "content_sha256": digest,
+            "save_decision": save_decision,
             "metadata": metadata or {},
         }
 

--- a/il_supermarket_scarper/utils/scraper_status.py
+++ b/il_supermarket_scarper/utils/scraper_status.py
@@ -88,30 +88,36 @@ class ScraperStatus:
             "extracted_successfully": results.extract_succefully,
             "error_message": results.error,
             "restart_and_retry": results.restart_and_retry,
+            "content_sha256": results.content_sha256,
+            "save_decision": results.save_decision,
         }
         self._insert_event(ScraperStatus.DOWNLOADED, **event_data)
         self._add_downloaded_files_to_list(results)
 
     async def filter_already_downloaded(self, filelist, by_function=lambda x: x):
-        """Filter files already existing in long-term memory or previously downloaded."""
+        """Skip listings whose FileEntry hash is already verified."""
+        del by_function
         async for file in filelist:
-            already_downloaded = self.database.already_downloaded(
-                self.VERIFIED_DOWNLOADS, {"file_name": by_function(file)}
-            )
-            if not already_downloaded:
+            if not self.database.already_downloaded(
+                self.VERIFIED_DOWNLOADS, {"listing_hash": file.listing_hash()}
+            ):
                 yield file
 
     def _add_downloaded_files_to_list(self, results: ScrapingResult):
         """Add downloaded files to the database collection."""
-        if results.extract_succefully:
-            self.database.insert_document(
-                self.VERIFIED_DOWNLOADS,
-                {
-                    "file_name": results.file_name,
-                    "system_timestamp": _now(),
-                    "task_id": self.task_id,
-                },
-            )
+        if not results.extract_succefully:
+            return
+        self.database.insert_document(
+            self.VERIFIED_DOWNLOADS,
+            {
+                "file_name": results.file_name,
+                "system_timestamp": _now(),
+                "task_id": self.task_id,
+                "content_sha256": results.content_sha256,
+                "save_decision": results.save_decision,
+                "listing_hash": results.file_entry.listing_hash(),
+            },
+        )
 
     def on_scrape_completed(
         self, folder_name: str, completed_successfully: bool = True

--- a/il_supermarket_scarper/utils/scraper_status_contract.py
+++ b/il_supermarket_scarper/utils/scraper_status_contract.py
@@ -100,6 +100,8 @@ class DownloadedStatus(BaseModel):
     extracted_successfully: bool
     error_message: Optional[str] = None
     restart_and_retry: bool = False
+    content_sha256: Optional[str] = None
+    save_decision: Optional[str] = None
 
 
 class FailedStatus(BaseModel):
@@ -133,6 +135,9 @@ class VerifiedDownload(BaseModel):
     task_id: str
     file_name: FileName
     system_timestamp: datetime
+    content_sha256: Optional[str] = None
+    save_decision: Optional[str] = None
+    listing_hash: Optional[str] = None
 
 
 # Union type for all possible status events
@@ -156,14 +161,16 @@ class ScraperStatusOutput(BaseModel):
 
     def _build_per_file_status_data(self):
         """
-        Build per-file status records and status counters.
+        Build per-file status flags and event counts.
+
+        Listing sites can emit the same FileNm more than once; that is a
+        real listing, not a contract failure. ``saw``, ``collected``,
+        ``downloaded``, and ``verified`` may appear more than once for
+        that name. ``failed`` should not.
 
         Returns:
-            A tuple of (per_file_dict, per_file_status_counter_dict)
-            - per_file_dict: Maps file name to status flags
-                (collected, downloaded, failed, verified)
-            - per_file_status_counter_dict: Maps file name to list of status types
-                for duplicate detection
+            Maps file name to status flags, counts, and whether a
+            download extracted successfully.
         """
 
         per_file = defaultdict(
@@ -173,33 +180,39 @@ class ScraperStatusOutput(BaseModel):
                 "downloaded": False,
                 "failed": False,
                 "verified": False,
+                "extracted_successfully": False,
+                "counts": defaultdict(int),
             }
         )
-        per_file_status_counter = defaultdict(list)
 
         for event in self.events:
             if isinstance(event, SawStatus):
-                fn = event.file_name
-                per_file[fn]["saw"] = True
-                per_file_status_counter[fn].append("saw")
+                per_file[event.file_name]["saw"] = True
+                per_file[event.file_name]["counts"]["saw"] += 1
             elif isinstance(event, CollectedStatus):
                 per_file[event.file_name]["collected"] = True
-                per_file_status_counter[event.file_name].append("collected")
+                per_file[event.file_name]["counts"]["collected"] += 1
             elif isinstance(event, DownloadedStatus):
-                fn = event.file_name
-                per_file[fn]["downloaded"] = True
-                per_file_status_counter[fn].append("downloaded")
+                per_file[event.file_name]["downloaded"] = True
+                per_file[event.file_name]["counts"]["downloaded"] += 1
+                if event.extracted_successfully:
+                    per_file[event.file_name]["extracted_successfully"] = True
             elif isinstance(event, FailedStatus):
-                fn = event.file_name
-                per_file[fn]["failed"] = True
-                per_file_status_counter[fn].append("failed")
+                per_file[event.file_name]["failed"] = True
+                per_file[event.file_name]["counts"]["failed"] += 1
 
         for vd in self.verified_downloads:
-            fn = vd.file_name
-            per_file[fn]["verified"] = True
-            per_file_status_counter[fn].append("verified")
+            per_file[vd.file_name]["verified"] = True
+            per_file[vd.file_name]["counts"]["verified"] += 1
 
-        return per_file, per_file_status_counter
+        return per_file
+
+    def _started_limit(self):
+        """Return the scrape limit from started status, or None."""
+        for event in self.global_status:
+            if isinstance(event, StartedStatus):
+                return event.limit
+        return None
 
     @staticmethod
     def _validate_file_lifecycle(status: dict) -> bool:
@@ -228,54 +241,52 @@ class ScraperStatusOutput(BaseModel):
         if status["verified"]:
             if not status["downloaded"]:
                 return False
+        # A successful extract must be recorded as verified.
+        if status["extracted_successfully"] and not status["verified"]:
+            return False
         return True
 
     @staticmethod
-    def _has_duplicate_statuses(status_counter_list: list) -> bool:
-        """Check if a file has duplicate status types."""
-        from collections import Counter  # pylint: disable=import-outside-toplevel
-
-        status_counter = Counter(status_counter_list)
-        for count in status_counter.values():
-            if count > 1:
-                return True  # Duplicate status type found
-        return False
+    def _has_duplicate_attempt_events(status: dict) -> bool:
+        """A file may be collected/downloaded twice; it must not fail twice."""
+        return status["counts"]["failed"] > 1
 
     def validate_file_status(self) -> bool:
         """
         Validate that the status file is valid.
 
-        Ensures that for every file name that was actually attempted (downloaded,
-        failed, or verified), there is a reasonable 'story' for that file: saw ->
-        collected -> (downloaded or failed) -> (verified if downloaded)
+        For every file name that was actually attempted (downloaded, failed,
+        or verified):
 
-        Also validates that if a limit was set, only that many files were downloaded.
+        - Lifecycle: saw -> collected -> (downloaded or failed) ->
+          (verified if extract succeeded)
+        - Duplicate ``saw`` / collected / downloaded / verified is allowed
+          (listing listed the same dump twice)
+        - Duplicate ``failed`` is not
+        - If a started ``limit`` is set, downloaded file names must not
+          exceed it
 
         Note: Files that were only saw/collected but never attempted (e.g., due to limit
         constraints) are not validated, as they were never intended to be downloaded.
         """
-        per_file, per_file_status_counter = self._build_per_file_status_data()
-
-        # Count successfully downloaded files (downloaded and verified)
+        per_file = self._build_per_file_status_data()
         downloaded_count = 0
-        for fn, status in per_file.items():
-            # Count files that were successfully downloaded
+
+        for status in per_file.values():
             if status["downloaded"]:
                 downloaded_count += 1
-
-        # Only validate files that were actually attempted (downloaded, failed, or verified)
-        # Files that were only saw/collected but never attempted shouldn't be validated
-        for fn, status in per_file.items():
-            # Skip validation for files that were only saw/collected but never attempted
             if (status["saw"] or status["collected"]) and not (
                 status["downloaded"] or status["failed"] or status["verified"]
             ):
                 continue
 
-            # Validate files that were actually attempted
             if not self._validate_file_lifecycle(status):
                 return False
-            if self._has_duplicate_statuses(per_file_status_counter[fn]):
+            if self._has_duplicate_attempt_events(status):
                 return False
+
+        limit = self._started_limit()
+        if limit is not None and downloaded_count > limit:
+            return False
 
         return True

--- a/il_supermarket_scarper/utils/scraping_result.py
+++ b/il_supermarket_scarper/utils/scraping_result.py
@@ -1,7 +1,10 @@
 from typing import Optional
 
+from .file_entry import FileEntry
+from .file_output import SaveDecision
 
-class ScrapingResult:
+
+class ScrapingResult:  # pylint: disable=too-many-instance-attributes
     """
     Represents the result of a scraping operation.
     Holds metadata, status, error information, and supports len().
@@ -9,27 +12,36 @@ class ScrapingResult:
     Example::
 
         ScrapingResult(
-            file_name='Price7290875100001-009-202601121522',
+            file_entry=FileEntry(
+                name='Price7290875100001-009-202601121522',
+                url='http://example.test/file',
+                size=1,
+            ),
             downloaded=True,
+            save_decision=SaveDecision.CREATED,
             extract_succefully=True,
-            error=None,
-            restart_and_retry=False,
-            source_corrupt=False,
+            content_sha256='abc',
         )
     """
 
     def __init__(
         self,
-        file_name: str,
+        file_entry: FileEntry,
         downloaded: bool,
+        save_decision: Optional[SaveDecision],
         extract_succefully: bool,
+        content_sha256: Optional[str] = None,
         error: Optional[str] = None,
         restart_and_retry: bool = False,
         source_corrupt: bool = False,
     ):
-        self.file_name = file_name
+        self.file_entry = file_entry
+        self.file_name = file_entry.name
         self.downloaded = downloaded
+        self.save_decision = getattr(save_decision, "value", save_decision)
         self.extract_succefully = extract_succefully
+        # Only set if the file was downloaded and extracted successfully
+        self.content_sha256 = content_sha256
         self.error = error
         self.restart_and_retry = restart_and_retry
         # True when the remote file itself is truncated/corrupt (download size

--- a/il_supermarket_scarper/utils/state.py
+++ b/il_supermarket_scarper/utils/state.py
@@ -4,12 +4,10 @@ class FilterState:  # pylint: disable=too-many-instance-attributes
     def __init__(self):
         self.total_input = 0
         self.after_already_downloaded = 0
-        self.after_unique = 0
         self.after_store_id = 0
         self.after_file_types = 0
         self.after_date_filter = 0
         self.final_output = 0
         self.files_was_filtered_since_already_download = False
-        self.unique_seen = set()
         self.file_pass_limit = 0
         self.should_exit = False

--- a/il_supermarket_scarper/utils/tests/test_file_output.py
+++ b/il_supermarket_scarper/utils/tests/test_file_output.py
@@ -13,6 +13,7 @@ from il_supermarket_scarper.utils import (
     InMemoryQueueHandler,
     ScraperConfig,
 )
+from il_supermarket_scarper.utils.file_output import SaveDecision, content_sha256
 
 
 class TestFileOutput:
@@ -334,6 +335,133 @@ class TestFileOutput:
                 assert result["extract_successfully"] is False
                 assert result["error"]
                 assert "gzip truncated" in result["error"]
+
+        asyncio.run(run_test())
+
+    def test_disk_output_rewrites_same_bytes(self):
+        """Identical content may reuse the same path."""
+
+        async def run_test():
+            with tempfile.TemporaryDirectory() as tmpdir:
+                output = DiskFileOutput(tmpdir, extract_gz=False)
+                payload = b"<xml>same</xml>"
+                first = await output.save_file(
+                    file_link="http://example.com/a.xml",
+                    file_name="PromoFull7290-001.xml",
+                    file_content=payload,
+                )
+                second = await output.save_file(
+                    file_link="http://example.com/a.xml",
+                    file_name="PromoFull7290-001.xml",
+                    file_content=payload,
+                )
+                assert first["file_name"] == "PromoFull7290-001.xml"
+                assert second["file_name"] == "PromoFull7290-001.xml"
+                assert first["save_decision"] == SaveDecision.CREATED
+                assert second["save_decision"] == SaveDecision.REWROTE_SAME
+                assert first["content_sha256"] == content_sha256(payload)
+                assert os.listdir(tmpdir) == ["PromoFull7290-001.xml"]
+                writes = {"n": 0}
+                original_write = output._write_file  # pylint: disable=protected-access
+
+                def counted_write(file_path, content):
+                    writes["n"] += 1
+                    original_write(file_path, content)
+
+                output._write_file = counted_write  # pylint: disable=protected-access
+                third = await output.save_file(
+                    file_link="http://example.com/a.xml",
+                    file_name="PromoFull7290-001.xml",
+                    file_content=payload,
+                )
+                assert third["save_decision"] == SaveDecision.REWROTE_SAME
+                assert writes["n"] == 0
+
+        asyncio.run(run_test())
+
+    def test_disk_output_keeps_different_bytes_under_same_name(self):
+        """Different content keeps the first file; status records the new hash."""
+
+        async def run_test():
+            with tempfile.TemporaryDirectory() as tmpdir:
+                output = DiskFileOutput(tmpdir, extract_gz=False)
+                first_bytes = b"<xml>one</xml>"
+                second_bytes = b"<xml>two</xml>"
+                first = await output.save_file(
+                    file_link="http://example.com/a.xml",
+                    file_name="PromoFull7290-001.xml",
+                    file_content=first_bytes,
+                )
+                second = await output.save_file(
+                    file_link="http://example.com/b.xml",
+                    file_name="PromoFull7290-001.xml",
+                    file_content=second_bytes,
+                )
+                assert first["file_name"] == second["file_name"] == "PromoFull7290-001.xml"
+                assert first["save_decision"] == SaveDecision.CREATED
+                assert second["save_decision"] == SaveDecision.HASH_MISMATCH
+                assert second["content_sha256"] == content_sha256(second_bytes)
+                assert os.listdir(tmpdir) == ["PromoFull7290-001.xml"]
+                with open(os.path.join(tmpdir, "PromoFull7290-001.xml"), "rb") as f:
+                    assert f.read() == first_bytes
+
+        asyncio.run(run_test())
+
+    def test_queue_output_rewrites_same_bytes(self):
+        """Identical content may reuse the same queue file name."""
+
+        async def run_test():
+            handler = InMemoryQueueHandler("same_bytes")
+            output = QueueFileOutput(handler, extract_gz=False)
+            payload = b"<xml>same</xml>"
+            first = await output.save_file(
+                file_link="http://example.com/a.xml",
+                file_name="PromoFull7290-001.xml",
+                file_content=payload,
+            )
+            second = await output.save_file(
+                file_link="http://example.com/a.xml",
+                file_name="PromoFull7290-001.xml",
+                file_content=payload,
+            )
+            assert first["save_decision"] == SaveDecision.CREATED
+            assert second["save_decision"] == SaveDecision.REWROTE_SAME
+            assert first["file_name"] == second["file_name"] == "PromoFull7290-001.xml"
+            await handler.close()
+            names = []
+            async for message in handler.get_all_messages():
+                names.append(message["file_name"])
+            assert names == ["PromoFull7290-001.xml"]
+
+        asyncio.run(run_test())
+
+    def test_queue_output_keeps_different_bytes_under_same_name(self):
+        """Different content does not enqueue a second name; status records the hash."""
+
+        async def run_test():
+            handler = InMemoryQueueHandler("conflict")
+            output = QueueFileOutput(handler, extract_gz=False)
+            first_bytes = b"<xml>one</xml>"
+            second_bytes = b"<xml>two</xml>"
+            first = await output.save_file(
+                file_link="http://example.com/a.xml",
+                file_name="PromoFull7290-001.xml",
+                file_content=first_bytes,
+            )
+            second = await output.save_file(
+                file_link="http://example.com/b.xml",
+                file_name="PromoFull7290-001.xml",
+                file_content=second_bytes,
+            )
+            assert first["file_name"] == second["file_name"] == "PromoFull7290-001.xml"
+            assert first["save_decision"] == SaveDecision.CREATED
+            assert second["save_decision"] == SaveDecision.HASH_MISMATCH
+            assert second["content_sha256"] == content_sha256(second_bytes)
+            await output.close()
+            names = []
+            async for message in handler.get_all_messages():
+                names.append(message["file_name"])
+            assert names == ["PromoFull7290-001.xml"]
 
         asyncio.run(run_test())
 

--- a/il_supermarket_scarper/utils/tests/test_scraper_status_contract.py
+++ b/il_supermarket_scarper/utils/tests/test_scraper_status_contract.py
@@ -1,0 +1,158 @@
+"""Status-contract validation: duplicate listing events are ok; two fails are not."""
+
+import unittest
+from datetime import datetime
+
+from il_supermarket_scarper.utils.scraper_status_contract import (
+    CollectedStatus,
+    DownloadedStatus,
+    FailedStatus,
+    SawStatus,
+    ScraperStatusOutput,
+    StartedStatus,
+    VerifiedDownload,
+)
+
+FILE = "PromoFull7290058156016-019-502-20260907-054854"
+TASK = "task-1"
+NOW = datetime(2026, 9, 7, 12, 0, 0)
+LINK = "http://supersapir.binaprojects.com/Download.aspx?FileNm=" + FILE
+
+
+def _saw(**kwargs):
+    return SawStatus(task_id=TASK, file_name=FILE, link=LINK, **kwargs)
+
+
+def _collected():
+    return CollectedStatus(task_id=TASK, file_name=FILE, link_collected=LINK)
+
+
+def _downloaded(extracted=True, **kwargs):
+    return DownloadedStatus(
+        task_id=TASK,
+        file_name=FILE,
+        downloaded_successfully=True,
+        extracted_successfully=extracted,
+        **kwargs,
+    )
+
+
+def _verified():
+    return VerifiedDownload(task_id=TASK, file_name=FILE, system_timestamp=NOW)
+
+
+def _started(limit=None):
+    return StartedStatus(task_id=TASK, limit=limit)
+
+
+class TestScraperStatusContract(unittest.TestCase):
+    """validate_file_status extra rules."""
+
+    def test_duplicate_saw_of_same_dump_is_valid(self):
+        """SuperSapir lists the same FileNm twice; one download is still valid."""
+        status = ScraperStatusOutput(
+            global_status=[_started(limit=1)],
+            events=[_saw(), _saw(), _collected(), _downloaded()],
+            verified_downloads=[_verified()],
+        )
+        self.assertTrue(status.validate_file_status())
+
+    def test_duplicate_download_of_same_listing_is_valid(self):
+        """Same FileNm downloaded twice (same or different hash) is valid."""
+        status = ScraperStatusOutput(
+            events=[
+                _saw(),
+                _saw(),
+                _collected(),
+                _collected(),
+                _downloaded(
+                    content_sha256="aa",
+                    save_decision="created",
+                ),
+                _downloaded(
+                    content_sha256="bb",
+                    save_decision="hash_mismatch",
+                ),
+            ],
+            verified_downloads=[
+                VerifiedDownload(
+                    task_id=TASK,
+                    file_name=FILE,
+                    system_timestamp=NOW,
+                    content_sha256="aa",
+                    save_decision="created",
+                ),
+                VerifiedDownload(
+                    task_id=TASK,
+                    file_name=FILE,
+                    system_timestamp=NOW,
+                    content_sha256="bb",
+                    save_decision="hash_mismatch",
+                ),
+            ],
+        )
+        self.assertTrue(status.validate_file_status())
+
+    def test_duplicate_failed_is_invalid(self):
+        """Two failed events for one file name are a contract break."""
+        status = ScraperStatusOutput(
+            events=[
+                _saw(),
+                _collected(),
+                FailedStatus(task_id=TASK, file_name=FILE, download_url=LINK),
+                FailedStatus(task_id=TASK, file_name=FILE, download_url=LINK),
+            ],
+        )
+        self.assertFalse(status.validate_file_status())
+
+    def test_successful_extract_without_verified_is_invalid(self):
+        """A successful extract must also be recorded as verified."""
+        status = ScraperStatusOutput(
+            events=[_saw(), _collected(), _downloaded(extracted=True)],
+            verified_downloads=[],
+        )
+        self.assertFalse(status.validate_file_status())
+
+    def test_failed_extract_without_verified_is_valid(self):
+        """Failed extract can remain downloaded-only."""
+        status = ScraperStatusOutput(
+            events=[_saw(), _collected(), _downloaded(extracted=False)],
+        )
+        self.assertTrue(status.validate_file_status())
+
+    def test_limit_not_exceeded(self):
+        """Started limit must not be exceeded by downloaded files."""
+        other = "PromoFull7290058156016-024-399-20260907-000001"
+        status = ScraperStatusOutput(
+            global_status=[_started(limit=1)],
+            events=[
+                _saw(),
+                _collected(),
+                _downloaded(),
+                SawStatus(task_id=TASK, file_name=other, link=LINK),
+                CollectedStatus(task_id=TASK, file_name=other, link_collected=LINK),
+                DownloadedStatus(
+                    task_id=TASK,
+                    file_name=other,
+                    downloaded_successfully=True,
+                    extracted_successfully=True,
+                ),
+            ],
+            verified_downloads=[
+                _verified(),
+                VerifiedDownload(
+                    task_id=TASK, file_name=other, system_timestamp=NOW
+                ),
+            ],
+        )
+        self.assertFalse(status.validate_file_status())
+
+    def test_failed_file_needs_collected(self):
+        """A failed download still needs a collected event."""
+        status = ScraperStatusOutput(
+            events=[
+                _saw(),
+                FailedStatus(task_id=TASK, file_name=FILE, download_url=None),
+            ],
+        )
+        self.assertFalse(status.validate_file_status())

--- a/scripts/test_validate_downloads.py
+++ b/scripts/test_validate_downloads.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from il_supermarket_scarper.utils import ScrapingResult
+from il_supermarket_scarper.utils import FileEntry, ScrapingResult
 
 from scripts.validate_downloads import (
     consume_until_failure,
@@ -11,18 +11,24 @@ from scripts.validate_downloads import (
 )
 
 
+def _entry(name: str) -> FileEntry:
+    return FileEntry(name=name, url=f"http://example.test/{name}", size=1)
+
+
 def _ok(name: str) -> ScrapingResult:
     return ScrapingResult(
-        file_name=name,
+        file_entry=_entry(name),
         downloaded=True,
+        save_decision=None,
         extract_succefully=True,
     )
 
 
 def _fail(name: str, error: str) -> ScrapingResult:
     return ScrapingResult(
-        file_name=name,
+        file_entry=_entry(name),
         downloaded=False,
+        save_decision=None,
         extract_succefully=False,
         error=error,
     )
@@ -30,8 +36,9 @@ def _fail(name: str, error: str) -> ScrapingResult:
 
 def _corrupt(name: str) -> ScrapingResult:
     return ScrapingResult(
-        file_name=name,
+        file_entry=_entry(name),
         downloaded=True,
+        save_decision=None,
         extract_succefully=False,
         error="source corrupt after 3 downloads: extract failed",
         source_corrupt=True,
@@ -47,8 +54,9 @@ class TestDownloadHelpers(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(
             is_download_ok(
                 ScrapingResult(
-                    file_name="a",
+                    file_entry=_entry("a"),
                     downloaded=True,
+                    save_decision=None,
                     extract_succefully=False,
                     error="extract failed",
                 )

--- a/scripts/validate_downloads.py
+++ b/scripts/validate_downloads.py
@@ -66,6 +66,7 @@ class ExtractAndDropFileOutput(FileOutput):
     """Extract to prove the download, then drop bytes so a full scrape fits on disk."""
 
     def __init__(self, storage_path: str):
+        super().__init__()
         self.storage_path = storage_path
         os.makedirs(storage_path, exist_ok=True)
 

--- a/scripts/validate_ui_vs_scraper.py
+++ b/scripts/validate_ui_vs_scraper.py
@@ -95,13 +95,15 @@ def norm_name(name: Optional[str]) -> str:
     return value
 
 
-def pick_filename(first: Any, second: Any) -> Optional[str]:
-    """Normalize collect_files_details yield order.
+def pick_filename(*parts: Any) -> Optional[str]:
+    """Normalize collect_files_details yield to a filename.
 
-    Web engines yield ``(url, name)``; Cerberus yields ``(name, url)``.
+    Engines yield ``FileEntry``. Older tuple orders are still accepted.
     """
+    if len(parts) == 1 and hasattr(parts[0], "name"):
+        return parts[0].name
     candidates = []
-    for item in (first, second):
+    for item in parts:
         if isinstance(item, str) and item.strip():
             candidates.append(item.strip())
     if not candidates:
@@ -391,10 +393,10 @@ async def list_scraper_names(enum_name: str) -> Tuple[Set[str], Dict[str, Any]]:
                 meta["ui_landing"] = ui_listing_url(scraper, ui_path)
             meta["ui_clicks"] = list(ui_path.clicks)
         names: Set[str] = set()
-        async for first, second in scraper.collect_files_details_from_site(
+        async for item in scraper.collect_files_details_from_site(
             FilterState(), limit=None
         ):
-            filename = pick_filename(first, second)
+            filename = pick_filename(item)
             if filename:
                 names.add(norm_name(filename))
     return names, meta


### PR DESCRIPTION
## Summary
- Identify listings by `name+url+size` hash (same scrape and vs verified DB), not by FileNm alone.
- Stop dropping duplicate API listing names; yield `FileEntry` through the download pipeline.
- Same-scrape same extracted name: resolve by content sha256 (`created` / `rewrote_same` / `hash_mismatch`).

Split from #166 (PR 3/6). Stacks on the limit-after-filters PR.

## Test plan
- [ ] Engine listing-hash / duplicate-name tests
- [ ] FileOutput + status contract tests
- [ ] CI test-suite

Made with [Cursor](https://cursor.com)