### PR TITLE
perf: hydrate verified indexes once for save decisions

### DIFF
--- a/il_supermarket_scarper/engines/apsx.py
+++ b/il_supermarket_scarper/engines/apsx.py
@@ -43,6 +43,14 @@ class Aspx(WebBase, ABC):
                     published_at = FileEntry.parse_published_at(
                         x.get(self.listing_date_key), self.listing_date_format
                     )
+                elif self.listing_date_format and hasattr(x, "find_all"):
+                    # Matrix HTML rows: date is td[7] (1-based) under תאריך.
+                    cells = x.find_all("td")
+                    if len(cells) >= 7:
+                        published_at = FileEntry.parse_published_at(
+                            cells[6].get_text(strip=True),
+                            self.listing_date_format,
+                        )
                 yield FileEntry(
                     name=file_name,
                     url=download_url,

--- a/il_supermarket_scarper/engines/cerberus.py
+++ b/il_supermarket_scarper/engines/cerberus.py
@@ -8,6 +8,8 @@ from il_supermarket_scarper.utils import (
     fetch_file_from_ftp_to_memory,
     FileTypesFilters,
     ScrapingResult,
+    content_sha256,
+    SaveDecision,
 )
 from il_supermarket_scarper.utils.state import FilterState
 from .engine import Engine
@@ -186,6 +188,7 @@ class Cerberus(Engine):
         source_corrupt = False
         error = None
         result = None
+        saved_file_name = None
         max_attempts = 3
         try:
             ext = file_name.split(".")[-1] if "." in file_name else ""
@@ -208,36 +211,79 @@ class Cerberus(Engine):
                 if ext == "gz":
                     Logger.debug(f"File size is {len(file_content)} bytes.")
 
-                result = await self.storage_path.save_file(
-                    file_link="",  # FTP doesn't have a URL
-                    file_name=file_name,
-                    file_content=file_content,
-                    metadata={
-                        "chain": self.chain.value,
-                        "chain_id": self.chain_id,
-                        "original_filename": file_name,
-                        "source": "ftp",
-                        "published_at": entry.published_at,
-                    },
+                (
+                    file_content,
+                    extracted_name,
+                    extract_succefully,
+                    extract_error,
+                ) = await self.storage_path.extract_if_compressed(
+                    file_content,
+                    file_name,
+                    getattr(self.storage_path, "extract_gz", True),
                 )
-
-                extract_succefully = result.get("extract_successfully", False)
-                error = result.get("error")
-                if extract_succefully:
-                    Logger.debug(f"Done persisting file {file_name}")
-                    break
-
-                Logger.warning(
-                    f"Extract failed for {file_name} "
-                    f"(attempt {attempt}/{max_attempts}): {error}"
-                )
-                if attempt == max_attempts:
-                    source_corrupt = True
-                    error = (
-                        f"source corrupt after {max_attempts} downloads: "
-                        f"{error or 'extract failed'}"
+                error = extract_error
+                if not extract_succefully:
+                    Logger.warning(
+                        f"Extract failed for {file_name} "
+                        f"(attempt {attempt}/{max_attempts}): {error}"
                     )
-                    Logger.error(error)
+                    if attempt == max_attempts:
+                        source_corrupt = True
+                        error = (
+                            f"source corrupt after {max_attempts} downloads: "
+                            f"{error or 'extract failed'}"
+                        )
+                        Logger.error(error)
+                    continue
+
+                digest = content_sha256(file_content)
+                metadata = {
+                    "chain": self.chain.value,
+                    "chain_id": self.chain_id,
+                    "original_filename": file_name,
+                    "source": "ftp",
+                    "published_at": entry.published_at,
+                }
+                box = {"result": None}
+
+                async def _persist(
+                    content=file_content,
+                    name=extracted_name,
+                    meta=metadata,
+                    dig=digest,
+                ):
+                    box["result"] = await self.storage_path.save_file(
+                        file_link="",
+                        file_name=name,
+                        file_content=content,
+                        metadata=meta,
+                        save_decision=SaveDecision.CREATED,
+                        content_digest=dig,
+                    )
+
+                save_decision = await self.decide_and_persist(
+                    extracted_name,
+                    digest,
+                    entry.published_at,
+                    _persist,
+                    listing_hash=entry.listing_hash(),
+                )
+                if box["result"] is not None:
+                    result = box["result"]
+                    result["save_decision"] = save_decision
+                else:
+                    result = {
+                        "file_name": extracted_name,
+                        "saved": True,
+                        "extract_successfully": True,
+                        "error": None,
+                        "content_sha256": digest,
+                        "save_decision": save_decision,
+                        "metadata": metadata,
+                    }
+                saved_file_name = extracted_name
+                Logger.debug(f"Done persisting file {file_name}")
+                break
         except Exception as exception:  # pylint: disable=broad-except
             Logger.error(
                 f"Error downloading {file_name},extract_succefully={extract_succefully}"
@@ -256,4 +302,5 @@ class Cerberus(Engine):
             restart_and_retry=restart_and_retry,
             error=error,
             source_corrupt=source_corrupt,
+            saved_file_name=saved_file_name,
         )

--- a/il_supermarket_scarper/engines/engine.py
+++ b/il_supermarket_scarper/engines/engine.py
@@ -22,6 +22,8 @@ from il_supermarket_scarper.utils import (
     DiskFileOutput,
     ScrapingResult,
     async_url_connection_retry,
+    content_sha256,
+    SaveDecision,
 )
 from il_supermarket_scarper.utils.state import FilterState
 from il_supermarket_scarper.utils.databases import AbstractDataBase
@@ -801,9 +803,9 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
         error = None
         restart_and_retry = False
         source_corrupt = False
-        extract_succefully = False
         max_attempts = 3
         result = None
+        saved_file_name = None
 
         try:
             # Determine file name with extension (case-insensitive check)
@@ -823,53 +825,99 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
                 if file_name_with_ext.endswith(".gz"):
                     Logger.debug(f"File size is {len(file_content)} bytes.")
 
-                result = await self.storage_path.save_file(
-                    file_link=file_link,
-                    file_name=file_name_with_ext,
-                    file_content=file_content,
-                    metadata={
-                        "chain": self.chain.value,
-                        "chain_id": self.chain_id,
-                        "original_filename": file_name,
-                        "published_at": entry.published_at,
-                    },
+                (
+                    file_content,
+                    extracted_name,
+                    extract_ok,
+                    extract_error,
+                ) = await self.storage_path.extract_if_compressed(
+                    file_content,
+                    file_name_with_ext,
+                    getattr(self.storage_path, "extract_gz", True),
                 )
+                error = extract_error
+                if not extract_ok:
+                    Logger.warning(
+                        f"Extract failed for {file_name} "
+                        f"(attempt {attempt}/{max_attempts}): {error}"
+                    )
+                    if attempt == max_attempts:
+                        source_corrupt = True
+                        error = (
+                            f"source corrupt after {max_attempts} downloads: "
+                            f"{error or 'extract failed'}"
+                        )
+                        Logger.error(error)
+                    continue
 
-                extract_succefully = result.get("extract_successfully", False)
-                error = result.get("error")
-                if extract_succefully:
-                    return ScrapingResult(
-                        file_entry=entry,
-                        downloaded=downloaded,
-                        save_decision=result["save_decision"],
-                        extract_succefully=True,
-                        content_sha256=result["content_sha256"],
-                        error=None,
-                        restart_and_retry=False,
-                        source_corrupt=False,
+                digest = content_sha256(file_content)
+                metadata = {
+                    "chain": self.chain.value,
+                    "chain_id": self.chain_id,
+                    "original_filename": file_name,
+                    "published_at": entry.published_at,
+                }
+                box = {"result": None}
+
+                async def _persist(
+                    content=file_content,
+                    name=extracted_name,
+                    meta=metadata,
+                    dig=digest,
+                ):
+                    box["result"] = await self.storage_path.save_file(
+                        file_link=file_link,
+                        file_name=name,
+                        file_content=content,
+                        metadata=meta,
+                        save_decision=SaveDecision.CREATED,
+                        content_digest=dig,
                     )
 
-                Logger.warning(
-                    f"Extract failed for {file_name} "
-                    f"(attempt {attempt}/{max_attempts}): {error}"
+                save_decision = await self.decide_and_persist(
+                    extracted_name,
+                    digest,
+                    entry.published_at,
+                    _persist,
+                    listing_hash=entry.listing_hash(),
                 )
-                if attempt == max_attempts:
-                    source_corrupt = True
-                    error = (
-                        f"source corrupt after {max_attempts} downloads: "
-                        f"{error or 'extract failed'}"
-                    )
-                    Logger.error(error)
+                if box["result"] is not None:
+                    result = box["result"]
+                    result["save_decision"] = save_decision
+                else:
+                    result = {
+                        "file_name": extracted_name,
+                        "saved": True,
+                        "extract_successfully": True,
+                        "error": None,
+                        "content_sha256": digest,
+                        "save_decision": save_decision,
+                        "metadata": metadata,
+                    }
+
+                saved_file_name = extracted_name
+                return ScrapingResult(
+                    file_entry=entry,
+                    downloaded=downloaded,
+                    save_decision=result["save_decision"],
+                    extract_succefully=True,
+                    content_sha256=result["content_sha256"],
+                    error=None,
+                    restart_and_retry=False,
+                    source_corrupt=False,
+                    saved_file_name=saved_file_name,
+                )
 
             return ScrapingResult(
                 file_entry=entry,
                 downloaded=downloaded,
-                save_decision=result["save_decision"],
+                save_decision=None if result is None else result["save_decision"],
                 extract_succefully=False,
-                content_sha256=result["content_sha256"],
+                content_sha256=None if result is None else result["content_sha256"],
                 error=error,
                 restart_and_retry=False,
                 source_corrupt=source_corrupt,
+                saved_file_name=saved_file_name,
             )
 
         except RestartSessionError as exception:
@@ -891,4 +939,6 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
             error=error,
             restart_and_retry=restart_and_retry,
             source_corrupt=source_corrupt,
+            saved_file_name=saved_file_name,
         )
+

--- a/il_supermarket_scarper/engines/matrix.py
+++ b/il_supermarket_scarper/engines/matrix.py
@@ -8,6 +8,7 @@ class Matrix(Aspx):
     (support adveanced search: follow the instrucation the page)"""
 
     utilize_date_param = False
+    listing_date_format = "%d/%m/%Y %H:%M:%S"
 
     def __init__(
         self,

--- a/il_supermarket_scarper/engines/tests/test_engine.py
+++ b/il_supermarket_scarper/engines/tests/test_engine.py
@@ -194,6 +194,7 @@ class TestApplyLimitAfterFilters(unittest.IsolatedAsyncioTestCase):
                     "task_id": "previous",
                 },
             )
+            scraper._hydrate_verified_indexes()  # pylint: disable=protected-access
 
             async def listed():
                 yield first
@@ -223,6 +224,7 @@ class TestApplyLimitAfterFilters(unittest.IsolatedAsyncioTestCase):
                     "task_id": "previous",
                 },
             )
+            scraper._hydrate_verified_indexes()  # pylint: disable=protected-access
 
             async def listed():
                 yield entry
@@ -269,6 +271,7 @@ class TestApplyLimitAfterFilters(unittest.IsolatedAsyncioTestCase):
                     "task_id": "previous",
                 },
             )
+            scraper._hydrate_verified_indexes()  # pylint: disable=protected-access
 
             async def listed():
                 yield FileEntry(name=name, url="http://example.test/a", size=1)

--- a/il_supermarket_scarper/scrappers/nativ_hashed.py
+++ b/il_supermarket_scarper/scrappers/nativ_hashed.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from il_supermarket_scarper.engines.web import WebBase
-from il_supermarket_scarper.utils import DumpFolderNames, _now
+from il_supermarket_scarper.utils import DumpFolderNames, FileEntry, Logger, _now
 
 
 # Listed on gov.il as https://app.netiv-hesed.com/
@@ -9,6 +9,7 @@ class NetivHased(WebBase):
     """scraper for nativ Hased"""
 
     utilize_date_param = False
+    listing_date_format = "%d/%m/%Y %H:%M"
     # The site Date filter defaults to today; the UI can open prior days.
     _LISTING_LOOKBACK_DAYS = 3
 
@@ -44,3 +45,22 @@ class NetivHased(WebBase):
                 "url": f"{self.url}?{query}",
                 "method": "GET",
             }
+
+    async def extract_task_from_entry(self, all_trs):
+        """Extract download links; date is td[5] תאריך קובץ."""
+        for row in all_trs:
+            try:
+                href = row.a.attrs["href"]
+                name = self._file_name_from_href(href)
+                url = self._absolute_download_url(href)
+                size = self.get_file_size_from_entry(row)
+                cells = row.find_all("td")
+                date_text = cells[4].get_text(strip=True) if len(cells) >= 5 else ""
+                published_at = FileEntry.parse_published_at(
+                    date_text, self.listing_date_format
+                )
+                yield FileEntry(
+                    name=name, url=url, size=size, published_at=published_at
+                )
+            except (AttributeError, KeyError, IndexError, TypeError) as e:
+                Logger.warning(f"Error extracting task from entry: {e}")

--- a/il_supermarket_scarper/scrappers/victory.py
+++ b/il_supermarket_scarper/scrappers/victory.py
@@ -13,6 +13,7 @@ class _LaibcatalogApiScraper(ApiWebEngine):
     """Base scraper for laibcatalog.co.il API-based scrapers."""
 
     utilize_date_param = False
+    listing_date_format = "%Y-%m-%d %H:%M:%S"
 
     def __init__(self, chain, chain_id, file_output=None, status_database=None):
         super().__init__(
@@ -103,6 +104,9 @@ class _LaibcatalogApiScraper(ApiWebEngine):
                     name=base_name,
                     url=download_url,
                     size=file_size,
+                    published_at=FileEntry.parse_published_at(
+                        entry.get("fileDate"), self.listing_date_format
+                    ),
                 )
 
             except (AttributeError, KeyError, TypeError) as e:

--- a/il_supermarket_scarper/utils/__init__.py
+++ b/il_supermarket_scarper/utils/__init__.py
@@ -60,6 +60,9 @@ from .file_output import (
     QueueFileOutput,
     AbstractQueueHandler,
     InMemoryQueueHandler,
+    SaveDecision,
+    content_sha256,
+    should_persist,
 )
 from .scraper_config import ScraperConfig
 from .databases import JsonDataBase, MongoDataBase

--- a/il_supermarket_scarper/utils/connection.py
+++ b/il_supermarket_scarper/utils/connection.py
@@ -634,6 +634,11 @@ def _ftp_mlsd_size(facts):
         return None
 
 
+def _ftp_mlsd_published_at(facts):
+    """Parse MLSD modify fact (YYYYMMDDHHMMSS) to ISO published_at."""
+    return FileEntry.parse_published_at(facts.get("modify"), "%Y%m%d%H%M%S")
+
+
 def _include_ftp_mlsd_entry(name, facts, arg):
     """Whether an MLSD entry should be yielded as a downloadable file."""
     if facts.get("type") in ("dir", "cdir", "pdir"):
@@ -669,11 +674,13 @@ async def collect_from_ftp(  # pylint: disable=too-many-locals,too-many-statemen
     cancelled = threading.Event()
     ftp_box = {"ftp": None}
 
-    def emit(name, size):
+    def emit(name, size, published_at=None):
         if cancelled.is_set():
             return
         try:
-            loop.call_soon_threadsafe(results.put_nowait, (name, size))
+            loop.call_soon_threadsafe(
+                results.put_nowait, (name, size, published_at)
+            )
         except RuntimeError:
             # Event loop closed while the listing thread was still running.
             pass
@@ -691,7 +698,11 @@ async def collect_from_ftp(  # pylint: disable=too-many-locals,too-many-statemen
                     if cancelled.is_set():
                         return
                     if _include_ftp_mlsd_entry(name, facts, arg):
-                        emit(name, _ftp_mlsd_size(facts))
+                        emit(
+                            name,
+                            _ftp_mlsd_size(facts),
+                            _ftp_mlsd_published_at(facts),
+                        )
             except error_perm:
                 # MLSD not supported. SIZE cannot run while the NLST data
                 # connection is open, so either emit names immediately or
@@ -748,8 +759,10 @@ async def collect_from_ftp(  # pylint: disable=too-many-locals,too-many-statemen
             item = await results.get()
             if item is sentinel:
                 break
-            filename, size = item
-            yield FileEntry(name=filename, url=None, size=size)
+            filename, size, published_at = item
+            yield FileEntry(
+                name=filename, url=None, size=size, published_at=published_at
+            )
         await producer
     finally:
         cancelled.set()

--- a/il_supermarket_scarper/utils/databases/base.py
+++ b/il_supermarket_scarper/utils/databases/base.py
@@ -23,6 +23,10 @@ class AbstractDataBase(ABC):
         """Return the first matching document, or None."""
         return None
 
+    def list_documents(self, collection_name):  # pylint: disable=unused-argument
+        """Return all documents in a collection (empty list if missing)."""
+        return []
+
     @abstractmethod
     def get_last_modified(self):
         """Get the last modified timestamp when scraper last wrote to this database."""

--- a/il_supermarket_scarper/utils/databases/json_file.py
+++ b/il_supermarket_scarper/utils/databases/json_file.py
@@ -93,20 +93,26 @@ class JsonDataBase(AbstractDataBase):
 
     def find_document(self, collection_name, query):
         """Return the first matching document, or None."""
-        file_path = self._get_database_file_path()
-
-        if os.path.exists(file_path):
-            with open(file_path, "r", encoding="utf-8") as file:
-                try:
-                    data = json.load(file)
-
-                    if collection_name in data:
-                        for document in data[collection_name]:
-                            if all(item in document.items() for item in query.items()):
-                                return document
-                except json.JSONDecodeError:
-                    Logger.warning(f"File {file_path} is corrupted.")
+        for document in self.list_documents(collection_name):
+            if all(item in document.items() for item in query.items()):
+                return document
         return None
+
+    def list_documents(self, collection_name):
+        """Return all documents in a collection (empty list if missing)."""
+        file_path = self._get_database_file_path()
+        if not os.path.exists(file_path):
+            return []
+        with open(file_path, "r", encoding="utf-8") as file:
+            try:
+                data = json.load(file)
+            except json.JSONDecodeError:
+                Logger.warning(f"File {file_path} is corrupted.")
+                return []
+        docs = data.get(collection_name, [])
+        if not isinstance(docs, list):
+            return []
+        return docs
 
     def _update_last_modified(self):
         """Update the last modified timestamp to current time."""

--- a/il_supermarket_scarper/utils/databases/mongo.py
+++ b/il_supermarket_scarper/utils/databases/mongo.py
@@ -44,6 +44,12 @@ class MongoDataBase(AbstractDataBase):
             self.create_connection()
         return self.store_db[collection_name].find_one(query)
 
+    def list_documents(self, collection_name):
+        """Return all documents in a collection (empty list if missing)."""
+        if self.store_db is None:
+            self.create_connection()
+        return list(self.store_db[collection_name].find({}))
+
     def _update_last_modified(self):
         """Update the last modified timestamp to current time."""
         if self.store_db is None:

--- a/il_supermarket_scarper/utils/file_output.py
+++ b/il_supermarket_scarper/utils/file_output.py
@@ -4,7 +4,6 @@ import asyncio
 import hashlib
 import multiprocessing
 from abc import ABC, abstractmethod
-from contextlib import asynccontextmanager
 from enum import Enum
 from typing import Any, Dict, AsyncGenerator, Optional, Tuple
 import os
@@ -13,7 +12,7 @@ from .gzip_utils import extract_xml_from_gz_in_memory, is_compressed_content
 
 
 class SaveDecision(str, Enum):
-    """How FileOutput resolved a repeated file name.
+    """How a repeated file name was resolved before persist.
 
     Parsers split ``FileNm`` for type, chain, store, and date. Never suffix
     or rename; keep the original name and overwrite or re-queue in place.
@@ -30,115 +29,15 @@ def content_sha256(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
+def should_persist(save_decision: SaveDecision) -> bool:
+    """True when bytes should be written or sent (not a same-hash / stale no-op)."""
+    return save_decision in (SaveDecision.CREATED, SaveDecision.HASH_MISMATCH)
+
+
 class FileOutput(ABC):
     """Abstract base class for file output handlers."""
 
-    def __init__(self):
-        self._saved_digests: Dict[str, str] = {}
-        self._saved_published_at: Dict[str, str] = {}
-        self._save_locks: Dict[str, asyncio.Lock] = {}
-        self._save_locks_guard = asyncio.Lock()
-
-    async def _lock_for_name(self, file_name: str) -> asyncio.Lock:
-        """Serialize saves that share an extracted file name."""
-        async with self._save_locks_guard:
-            lock = self._save_locks.get(file_name)
-            if lock is None:
-                lock = asyncio.Lock()
-                self._save_locks[file_name] = lock
-            return lock
-
-    @asynccontextmanager
-    async def _locked_save_decision(
-        self,
-        file_name: str,
-        file_content: bytes,
-        published_at: Optional[str] = None,
-    ):
-        """Hold the per-name lock and yield (name, decision, digest)."""
-        lock = await self._lock_for_name(file_name)
-        async with lock:
-            yield self.resolve_save_name(file_name, file_content, published_at)
-
-    def resolve_save_name(
-        self,
-        file_name: str,
-        content: bytes,
-        published_at: Optional[str] = None,
-    ) -> Tuple[str, SaveDecision, str]:
-        """Keep ``file_name``. Compare sha256 against this scrape's memory.
-
-        Same hash is a no-op. Different hash is ``HASH_MISMATCH``: callers
-        overwrite the disk file or push the queue again, then remember the
-        new digest. An older ``published_at`` does not replace a newer file.
-        Digest is stored only after a successful write/send.
-        """
-        digest = content_sha256(content)
-        known = self._saved_digests.get(file_name)
-        if known is None:
-            return file_name, SaveDecision.CREATED, digest
-        stored_published = self._saved_published_at.get(file_name)
-        if (
-            published_at
-            and stored_published
-            and published_at < stored_published
-        ):
-            Logger.info(
-                f"{file_name} listed at {published_at} is older than "
-                f"already stored {stored_published}; keeping the newer file"
-            )
-            return file_name, SaveDecision.STALE_OLDER, digest
-        if known == digest:
-            return file_name, SaveDecision.REWROTE_SAME, digest
-        Logger.info(
-            f"{file_name} already stored with sha256={known}; "
-            f"downloaded sha256={digest}; overwriting / re-queueing"
-        )
-        return file_name, SaveDecision.HASH_MISMATCH, digest
-
-    def _should_persist(self, save_decision: SaveDecision) -> bool:
-        """True when bytes should be written or sent (not a same-hash no-op)."""
-        return save_decision in (SaveDecision.CREATED, SaveDecision.HASH_MISMATCH)
-
-    def _remember_digest(
-        self,
-        file_name: str,
-        digest: str,
-        published_at: Optional[str] = None,
-        save_decision: Optional[SaveDecision] = None,
-    ) -> None:
-        """Record sha256 and publish time after a successful write or skip-same."""
-        if save_decision == SaveDecision.STALE_OLDER:
-            return
-        if self._should_persist(save_decision) or save_decision is None:
-            self._saved_digests[file_name] = digest
-        if published_at:
-            known = self._saved_published_at.get(file_name)
-            if known is None or published_at >= known:
-                self._saved_published_at[file_name] = published_at
-
-    @abstractmethod
-    async def save_file(
-        self,
-        file_link: str,
-        file_name: str,
-        file_content: bytes,
-        metadata: Dict[str, Any] = None,
-    ) -> Dict[str, Any]:
-        """
-        Save a file and return status information.
-
-        Args:
-            file_link: The URL where the file was downloaded from
-            file_name: The name of the file
-            file_content: The raw file content as bytes
-            metadata: Optional metadata about the file (chain_id, store_id, etc.)
-
-        Returns:
-            Dict with keys: file_name, saved, error, metadata
-        """
-
-    async def _extract_if_compressed(
+    async def extract_if_compressed(
         self, file_content: bytes, file_name: str, extract_gz: bool = True
     ) -> Tuple[bytes, str, bool, Optional[str]]:
         """
@@ -164,6 +63,31 @@ class FileOutput(ABC):
         except Exception as e:  # pylint: disable=broad-except
             Logger.error(f"Failed to extract {file_name}: {e}")
             return file_content, file_name, False, str(e)
+
+    @abstractmethod
+    async def save_file(
+        self,
+        file_link: str,
+        file_name: str,
+        file_content: bytes,
+        metadata: Dict[str, Any] = None,
+        save_decision: SaveDecision = SaveDecision.CREATED,
+        content_digest: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Persist already-extracted bytes when ``save_decision`` requires it.
+
+        Args:
+            file_link: The URL where the file was downloaded from
+            file_name: The extracted file name
+            file_content: The final (extracted) file content as bytes
+            metadata: Optional metadata about the file (chain_id, store_id, etc.)
+            save_decision: Whether to write/send or skip
+            content_digest: Precomputed sha256 of ``file_content``
+
+        Returns:
+            Dict with keys: file_name, saved, error, content_sha256, save_decision, metadata
+        """
 
     @abstractmethod
     def make_sure_accassible(self):
@@ -199,7 +123,6 @@ class DiskFileOutput(FileOutput):
         self.storage_path = storage_path
         self.extract_gz = extract_gz
         os.makedirs(storage_path, exist_ok=True)
-        super().__init__()
 
     async def save_file(
         self,
@@ -207,37 +130,20 @@ class DiskFileOutput(FileOutput):
         file_name: str,
         file_content: bytes,
         metadata: Dict[str, Any] = None,
+        save_decision: SaveDecision = SaveDecision.CREATED,
+        content_digest: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Decompress file if needed and write final content to disk."""
+        """Write final content to disk when ``save_decision`` requires it."""
         saved = False
-        extract_successfully = False
         error = None
-        digest = None
-        save_decision = None
+        digest = content_digest or content_sha256(file_content)
+        file_save_path = os.path.join(self.storage_path, file_name)
 
         try:
-            # Extract if it's compressed
-            file_content, file_name, extract_successfully, extract_error = (
-                await self._extract_if_compressed(
-                    file_content, file_name, self.extract_gz
+            if should_persist(save_decision):
+                await asyncio.to_thread(
+                    self._write_file, file_save_path, file_content
                 )
-            )
-            if not extract_successfully:
-                error = extract_error
-
-            published_at = (metadata or {}).get("published_at")
-            async with self._locked_save_decision(
-                file_name, file_content, published_at
-            ) as (file_name, save_decision, digest):
-                file_save_path = os.path.join(self.storage_path, file_name)
-                if self._should_persist(save_decision):
-                    await asyncio.to_thread(
-                        self._write_file, file_save_path, file_content
-                    )
-                self._remember_digest(
-                    file_name, digest, published_at, save_decision
-                )
-
             saved = True
             Logger.debug(
                 f"Saved {file_link} to {file_save_path} sha256={digest} "
@@ -254,7 +160,7 @@ class DiskFileOutput(FileOutput):
         return {
             "file_name": file_name,
             "saved": saved,
-            "extract_successfully": extract_successfully,
+            "extract_successfully": True,
             "error": error,
             "content_sha256": digest,
             "save_decision": save_decision,
@@ -304,7 +210,6 @@ class QueueFileOutput(FileOutput):
         self.storage_path = storage_path
         self.extract_gz = extract_gz
         os.makedirs(storage_path, exist_ok=True)
-        super().__init__()
 
     async def save_file(
         self,
@@ -312,46 +217,30 @@ class QueueFileOutput(FileOutput):
         file_name: str,
         file_content: bytes,
         metadata: Dict[str, Any] = None,
+        save_decision: SaveDecision = SaveDecision.CREATED,
+        content_digest: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Send file to queue, extracting compressed files first."""
+        """Send file to queue when ``save_decision`` requires it."""
         saved = False
-        extract_successfully = False
         error = None
-        digest = None
-        save_decision = None
+        digest = content_digest or content_sha256(file_content)
 
         try:
-            # Extract if it's compressed (detected by magic bytes)
-            file_content, file_name, extract_successfully, extract_error = (
-                await self._extract_if_compressed(
-                    file_content, file_name, self.extract_gz
-                )
+            if should_persist(save_decision):
+                message = {
+                    "file_name": file_name,
+                    "file_link": file_link,
+                    "file_content": file_content,
+                    "content_sha256": digest,
+                    "save_decision": save_decision,
+                    "metadata": metadata or {},
+                }
+                await self.queue_handler.send(message)
+            saved = True
+            Logger.debug(
+                f"Queue {file_name} sha256={digest} "
+                f"save_decision={save_decision}"
             )
-            if not extract_successfully:
-                error = extract_error
-            if extract_successfully:
-                published_at = (metadata or {}).get("published_at")
-                async with self._locked_save_decision(
-                    file_name, file_content, published_at
-                ) as (file_name, save_decision, digest):
-                    if self._should_persist(save_decision):
-                        message = {
-                            "file_name": file_name,
-                            "file_link": file_link,
-                            "file_content": file_content,
-                            "content_sha256": digest,
-                            "save_decision": save_decision,
-                            "metadata": metadata or {},
-                        }
-                        await self.queue_handler.send(message)
-                    self._remember_digest(
-                        file_name, digest, published_at, save_decision
-                    )
-                saved = True
-                Logger.debug(
-                    f"Queue {file_name} sha256={digest} "
-                    f"save_decision={save_decision}"
-                )
 
         except Exception as exception:  # pylint: disable=broad-except
             Logger.error(f"Error sending {file_link} to queue: {exception}")
@@ -363,7 +252,7 @@ class QueueFileOutput(FileOutput):
         return {
             "file_name": file_name,
             "saved": saved,
-            "extract_successfully": extract_successfully,
+            "extract_successfully": True,
             "error": error,
             "content_sha256": digest,
             "save_decision": save_decision,

--- a/il_supermarket_scarper/utils/scraper_status.py
+++ b/il_supermarket_scarper/utils/scraper_status.py
@@ -1,10 +1,12 @@
+import asyncio
 import os
 import traceback
-from typing import Optional
+from typing import Dict, Optional
 import uuid
 from .status import log_folder_details, _now
 from .databases import JsonDataBase, AbstractDataBase
-from .file_output import FileOutput
+from .file_output import FileOutput, SaveDecision, should_persist
+from .logger import Logger
 from .scraping_result import ScrapingResult
 
 
@@ -35,10 +37,15 @@ class ScraperStatus:
         else:
             self.database = status_database
         self.task_id = None
+        self._verified_listing_hashes: set = set()
+        self._saved_by_name: Dict[str, Dict[str, Optional[str]]] = {}
+        self._save_locks: Dict[str, asyncio.Lock] = {}
+        self._save_locks_guard = asyncio.Lock()
 
     def on_scraping_start(self, limit, files_types, **additional_info):
         """Report that scraping has started."""
         self.task_id = str(uuid.uuid4())
+        self._hydrate_verified_indexes()
 
         self._insert_global_status(
             ScraperStatus.STARTED,
@@ -46,6 +53,36 @@ class ScraperStatus:
             files_requested=files_types,
             **additional_info,
         )
+
+    def _hydrate_verified_indexes(self) -> None:
+        """Load verified_downloads once into O(1) listing/hash indexes."""
+        self._verified_listing_hashes = set()
+        self._saved_by_name = {}
+        for doc in self.database.list_documents(self.VERIFIED_DOWNLOADS):
+            listing_hash = doc.get("listing_hash")
+            if listing_hash:
+                self._verified_listing_hashes.add(listing_hash)
+            file_name = doc.get("file_name")
+            if not file_name:
+                continue
+            digest = doc.get("content_sha256")
+            published_at = doc.get("published_at")
+            known = self._saved_by_name.get(file_name)
+            if known is None:
+                self._saved_by_name[file_name] = {
+                    "content_sha256": digest,
+                    "published_at": published_at,
+                }
+                continue
+            stored_published = known.get("published_at")
+            if published_at and (
+                stored_published is None or published_at >= stored_published
+            ):
+                known["published_at"] = published_at
+                if digest:
+                    known["content_sha256"] = digest
+            elif known.get("content_sha256") is None and digest:
+                known["content_sha256"] = digest
 
     def register_saw_file(
         self,
@@ -101,9 +138,7 @@ class ScraperStatus:
         size is a new listing and must download. Rows without listing_hash
         (pre-clean DBs) do not skip.
         """
-        return self.database.already_downloaded(
-            self.VERIFIED_DOWNLOADS, {"listing_hash": file.listing_hash()}
-        )
+        return file.listing_hash() in self._verified_listing_hashes
 
     async def filter_already_downloaded(self, filelist, by_function=lambda x: x):
         """Skip listings already verified by listing_hash."""
@@ -112,10 +147,119 @@ class ScraperStatus:
             if not self._is_verified_listing(file):
                 yield file
 
+    async def _lock_for_name(self, file_name: str) -> asyncio.Lock:
+        """Serialize save decisions that share an extracted file name."""
+        async with self._save_locks_guard:
+            lock = self._save_locks.get(file_name)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._save_locks[file_name] = lock
+            return lock
+
+    def resolve_save_decision(
+        self,
+        file_name: str,
+        digest: str,
+        published_at: Optional[str] = None,
+    ) -> SaveDecision:
+        """Decide whether to persist bytes for ``file_name``.
+
+        Unknown name → CREATED. Older published_at → STALE_OLDER.
+        Same digest → REWROTE_SAME. Else → HASH_MISMATCH.
+        Missing dates allow overwrite when digests differ.
+        """
+        known = self._saved_by_name.get(file_name)
+        if known is None:
+            return SaveDecision.CREATED
+        stored_published = known.get("published_at")
+        if (
+            published_at
+            and stored_published
+            and published_at < stored_published
+        ):
+            Logger.info(
+                f"{file_name} listed at {published_at} is older than "
+                f"already stored {stored_published}; keeping the newer file"
+            )
+            return SaveDecision.STALE_OLDER
+        known_digest = known.get("content_sha256")
+        if known_digest is not None and known_digest == digest:
+            return SaveDecision.REWROTE_SAME
+        Logger.info(
+            f"{file_name} already stored with sha256={known_digest}; "
+            f"downloaded sha256={digest}; overwriting / re-queueing"
+        )
+        return SaveDecision.HASH_MISMATCH
+
+    def _remember_save(
+        self,
+        file_name: str,
+        digest: str,
+        published_at: Optional[str],
+        save_decision: SaveDecision,
+        listing_hash: Optional[str] = None,
+    ) -> None:
+        """Update in-memory indexes after a successful extract."""
+        if listing_hash:
+            self._verified_listing_hashes.add(listing_hash)
+        if save_decision == SaveDecision.STALE_OLDER:
+            return
+        entry = self._saved_by_name.setdefault(
+            file_name, {"content_sha256": None, "published_at": None}
+        )
+        if should_persist(save_decision) or entry.get("content_sha256") is None:
+            entry["content_sha256"] = digest
+        if published_at:
+            known = entry.get("published_at")
+            if known is None or published_at >= known:
+                entry["published_at"] = published_at
+
+    async def decide_and_persist(
+        self,
+        file_name: str,
+        digest: str,
+        published_at: Optional[str],
+        persist,
+        listing_hash: Optional[str] = None,
+    ) -> SaveDecision:
+        """Lock by name, decide, optionally persist, then update indexes.
+
+        ``persist`` is only awaited when bytes must be written/sent; it need
+        not receive the decision (caller already gated).
+        """
+        lock = await self._lock_for_name(file_name)
+        async with lock:
+            save_decision = self.resolve_save_decision(
+                file_name, digest, published_at
+            )
+            if should_persist(save_decision):
+                await persist()
+            self._remember_save(
+                file_name,
+                digest,
+                published_at,
+                save_decision,
+                listing_hash=listing_hash,
+            )
+            return save_decision
+
     def _add_downloaded_files_to_list(self, results: ScrapingResult):
         """Add downloaded files to the database collection."""
         if not results.extract_succefully:
             return
+        listing_hash = results.file_entry.listing_hash()
+        decision = (
+            SaveDecision(results.save_decision)
+            if results.save_decision
+            else SaveDecision.CREATED
+        )
+        self._remember_save(
+            results.file_name,
+            results.content_sha256,
+            results.file_entry.published_at,
+            decision,
+            listing_hash=listing_hash,
+        )
         self.database.insert_document(
             self.VERIFIED_DOWNLOADS,
             {
@@ -124,7 +268,7 @@ class ScraperStatus:
                 "task_id": self.task_id,
                 "content_sha256": results.content_sha256,
                 "save_decision": results.save_decision,
-                "listing_hash": results.file_entry.listing_hash(),
+                "listing_hash": listing_hash,
                 "published_at": results.file_entry.published_at,
             },
         )

--- a/il_supermarket_scarper/utils/scraping_result.py
+++ b/il_supermarket_scarper/utils/scraping_result.py
@@ -21,6 +21,7 @@ class ScrapingResult:  # pylint: disable=too-many-instance-attributes
             save_decision=SaveDecision.CREATED,
             extract_succefully=True,
             content_sha256='abc',
+            saved_file_name='Price7290875100001-009-202601121522.xml',
         )
     """
 
@@ -34,9 +35,11 @@ class ScrapingResult:  # pylint: disable=too-many-instance-attributes
         error: Optional[str] = None,
         restart_and_retry: bool = False,
         source_corrupt: bool = False,
+        saved_file_name: Optional[str] = None,
     ):
         self.file_entry = file_entry
-        self.file_name = file_entry.name
+        # Prefer post-extract name so verified digests match FileOutput keys.
+        self.file_name = saved_file_name or file_entry.name
         self.downloaded = downloaded
         self.save_decision = getattr(save_decision, "value", save_decision)
         self.extract_succefully = extract_succefully

--- a/il_supermarket_scarper/utils/tests/test_file_entry.py
+++ b/il_supermarket_scarper/utils/tests/test_file_entry.py
@@ -3,14 +3,18 @@
 import unittest
 
 from il_supermarket_scarper.engines.bina import Bina
+from il_supermarket_scarper.engines.matrix import Matrix
 from il_supermarket_scarper.engines.multipage_web import MultiPageWeb
 from il_supermarket_scarper.engines.publishprice import PublishPrice
 from il_supermarket_scarper.scrappers.city_market import CityMarketShops
 from il_supermarket_scarper.scrappers.hazihinam import HaziHinam
 from il_supermarket_scarper.scrappers.meshnat_yosef import MeshnatYosef1
+from il_supermarket_scarper.scrappers.nativ_hashed import NetivHased
 from il_supermarket_scarper.scrappers.shufersal import Shufersal
 from il_supermarket_scarper.scrappers.super_pharm import SuperPharm
+from il_supermarket_scarper.scrappers.victory import VictoryNewSource
 from il_supermarket_scarper.utils import FileEntry
+from il_supermarket_scarper.utils.connection import _ftp_mlsd_published_at
 
 
 class TestParsePublishedAt(unittest.TestCase):
@@ -79,6 +83,37 @@ class TestParsePublishedAt(unittest.TestCase):
             ),
             "2026-09-09T00:00:00",
         )
+
+    def test_victory_file_date(self):
+        self.assertEqual(
+            FileEntry.parse_published_at(
+                "2026-09-11 22:30:37", VictoryNewSource.listing_date_format
+            ),
+            "2026-09-11T22:30:37",
+        )
+
+    def test_matrix_td_date(self):
+        self.assertEqual(
+            FileEntry.parse_published_at(
+                "11/09/2026 06:27:02", Matrix.listing_date_format
+            ),
+            "2026-09-11T06:27:02",
+        )
+
+    def test_netiv_file_date(self):
+        self.assertEqual(
+            FileEntry.parse_published_at(
+                "11/09/2026 14:23", NetivHased.listing_date_format
+            ),
+            "2026-09-11T14:23:00",
+        )
+
+    def test_ftp_mlsd_modify(self):
+        self.assertEqual(
+            _ftp_mlsd_published_at({"modify": "20260911143037"}),
+            "2026-09-11T14:30:37",
+        )
+        self.assertIsNone(_ftp_mlsd_published_at({}))
 
     def test_wrong_format_is_none(self):
         """A scraper must not try every format; mismatch stays None."""

--- a/il_supermarket_scarper/utils/tests/test_file_output.py
+++ b/il_supermarket_scarper/utils/tests/test_file_output.py
@@ -85,11 +85,15 @@ class TestFileOutput:
 
             xml_content = b"<xml>test content</xml>"
             gzip_content = gzip.compress(xml_content)
-
+            content, name, ok, err = await output.extract_if_compressed(
+                gzip_content, "Stores7290058108879-000", extract_gz=True
+            )
+            assert ok is True
+            assert err is None
             result = await output.save_file(
                 file_link="http://example.com/Stores7290058108879-000",
-                file_name="Stores7290058108879-000",
-                file_content=gzip_content,
+                file_name=name,
+                file_content=content,
                 metadata={"chain": "KingStore"},
             )
 
@@ -212,11 +216,14 @@ class TestFileOutput:
 
                 xml_content = b"<xml>test content</xml>"
                 gzip_content = gzip.compress(xml_content)
-
+                content, name, ok, err = await output.extract_if_compressed(
+                    gzip_content, "test.xml.gz", extract_gz=True
+                )
+                assert ok is True and err is None
                 result = await output.save_file(
                     file_link="http://example.com/test.xml.gz",
-                    file_name="test.xml.gz",
-                    file_content=gzip_content,
+                    file_name=name,
+                    file_content=content,
                     metadata={"chain": "test"},
                 )
 
@@ -244,11 +251,14 @@ class TestFileOutput:
 
                 xml_content = b"<xml>test content</xml>"
                 gzip_content = gzip.compress(xml_content)
-
+                content, name, ok, err = await output.extract_if_compressed(
+                    gzip_content, "Stores7290058108879-000", extract_gz=True
+                )
+                assert ok is True and err is None
                 result = await output.save_file(
                     file_link="http://example.com/Stores7290058108879-000",
-                    file_name="Stores7290058108879-000",
-                    file_content=gzip_content,
+                    file_name=name,
+                    file_content=content,
                     metadata={"chain": "KingStore"},
                 )
 
@@ -326,20 +336,17 @@ class TestFileOutput:
             with tempfile.TemporaryDirectory() as tmpdir:
                 output = DiskFileOutput(tmpdir, extract_gz=True)
                 truncated = gzip.compress(b"<xml>test content</xml>")[:-20]
-                result = await output.save_file(
-                    file_link="http://example.com/test.xml.gz",
-                    file_name="test.xml.gz",
-                    file_content=truncated,
-                    metadata={"chain": "test"},
+                _content, _name, ok, err = await output.extract_if_compressed(
+                    truncated, "test.xml.gz", extract_gz=True
                 )
-                assert result["extract_successfully"] is False
-                assert result["error"]
-                assert "gzip truncated" in result["error"]
+                assert ok is False
+                assert err
+                assert "gzip truncated" in err
 
         asyncio.run(run_test())
 
-    def test_disk_output_rewrites_same_bytes(self):
-        """Identical content may reuse the same path."""
+    def test_disk_output_skips_write_on_rewrote_same(self):
+        """Caller can pass REWROTE_SAME so DiskFileOutput does not rewrite."""
 
         async def run_test():
             with tempfile.TemporaryDirectory() as tmpdir:
@@ -349,18 +356,8 @@ class TestFileOutput:
                     file_link="http://example.com/a.xml",
                     file_name="PromoFull7290-001.xml",
                     file_content=payload,
+                    save_decision=SaveDecision.CREATED,
                 )
-                second = await output.save_file(
-                    file_link="http://example.com/a.xml",
-                    file_name="PromoFull7290-001.xml",
-                    file_content=payload,
-                )
-                assert first["file_name"] == "PromoFull7290-001.xml"
-                assert second["file_name"] == "PromoFull7290-001.xml"
-                assert first["save_decision"] == SaveDecision.CREATED
-                assert second["save_decision"] == SaveDecision.REWROTE_SAME
-                assert first["content_sha256"] == content_sha256(payload)
-                assert os.listdir(tmpdir) == ["PromoFull7290-001.xml"]
                 writes = {"n": 0}
                 original_write = output._write_file  # pylint: disable=protected-access
 
@@ -369,18 +366,21 @@ class TestFileOutput:
                     original_write(file_path, content)
 
                 output._write_file = counted_write  # pylint: disable=protected-access
-                third = await output.save_file(
+                second = await output.save_file(
                     file_link="http://example.com/a.xml",
                     file_name="PromoFull7290-001.xml",
                     file_content=payload,
+                    save_decision=SaveDecision.REWROTE_SAME,
                 )
-                assert third["save_decision"] == SaveDecision.REWROTE_SAME
+                assert first["save_decision"] == SaveDecision.CREATED
+                assert second["save_decision"] == SaveDecision.REWROTE_SAME
                 assert writes["n"] == 0
+                assert os.listdir(tmpdir) == ["PromoFull7290-001.xml"]
 
         asyncio.run(run_test())
 
-    def test_disk_output_overwrites_different_bytes_under_same_name(self):
-        """Different content overwrites the file; parsers keep the original name."""
+    def test_disk_output_overwrites_on_hash_mismatch(self):
+        """HASH_MISMATCH overwrites the file under the original name."""
 
         async def run_test():
             with tempfile.TemporaryDirectory() as tmpdir:
@@ -391,11 +391,13 @@ class TestFileOutput:
                     file_link="http://example.com/a.xml",
                     file_name="PromoFull7290-001.xml",
                     file_content=first_bytes,
+                    save_decision=SaveDecision.CREATED,
                 )
                 second = await output.save_file(
                     file_link="http://example.com/b.xml",
                     file_name="PromoFull7290-001.xml",
                     file_content=second_bytes,
+                    save_decision=SaveDecision.HASH_MISMATCH,
                 )
                 assert first["file_name"] == second["file_name"] == "PromoFull7290-001.xml"
                 assert first["save_decision"] == SaveDecision.CREATED
@@ -407,33 +409,32 @@ class TestFileOutput:
 
         asyncio.run(run_test())
 
-    def test_disk_output_keeps_newer_published_at(self):
-        """An older listing must not overwrite a newer file of the same name."""
+    def test_disk_output_skips_write_on_stale_older(self):
+        """STALE_OLDER keeps the on-disk bytes."""
 
         async def run_test():
             with tempfile.TemporaryDirectory() as tmpdir:
                 output = DiskFileOutput(tmpdir, extract_gz=False)
-                newer = await output.save_file(
+                await output.save_file(
                     file_link="http://example.com/new.xml",
                     file_name="PromoFull7290-001.xml",
                     file_content=b"<xml>new</xml>",
-                    metadata={"published_at": "2026-09-08T14:18:00"},
+                    save_decision=SaveDecision.CREATED,
                 )
                 older = await output.save_file(
                     file_link="http://example.com/old.xml",
                     file_name="PromoFull7290-001.xml",
                     file_content=b"<xml>old</xml>",
-                    metadata={"published_at": "2026-09-08T10:00:00"},
+                    save_decision=SaveDecision.STALE_OLDER,
                 )
-                assert newer["save_decision"] == SaveDecision.CREATED
                 assert older["save_decision"] == SaveDecision.STALE_OLDER
                 with open(os.path.join(tmpdir, "PromoFull7290-001.xml"), "rb") as f:
                     assert f.read() == b"<xml>new</xml>"
 
         asyncio.run(run_test())
 
-    def test_queue_output_rewrites_same_bytes(self):
-        """Identical content may reuse the same queue file name."""
+    def test_queue_output_skips_send_on_rewrote_same(self):
+        """Identical content may skip a second queue send."""
 
         async def run_test():
             handler = InMemoryQueueHandler("same_bytes")
@@ -443,11 +444,13 @@ class TestFileOutput:
                 file_link="http://example.com/a.xml",
                 file_name="PromoFull7290-001.xml",
                 file_content=payload,
+                save_decision=SaveDecision.CREATED,
             )
             second = await output.save_file(
                 file_link="http://example.com/a.xml",
                 file_name="PromoFull7290-001.xml",
                 file_content=payload,
+                save_decision=SaveDecision.REWROTE_SAME,
             )
             assert first["save_decision"] == SaveDecision.CREATED
             assert second["save_decision"] == SaveDecision.REWROTE_SAME
@@ -472,11 +475,13 @@ class TestFileOutput:
                 file_link="http://example.com/a.xml",
                 file_name="PromoFull7290-001.xml",
                 file_content=first_bytes,
+                save_decision=SaveDecision.CREATED,
             )
             second = await output.save_file(
                 file_link="http://example.com/b.xml",
                 file_name="PromoFull7290-001.xml",
                 file_content=second_bytes,
+                save_decision=SaveDecision.HASH_MISMATCH,
             )
             assert first["file_name"] == second["file_name"] == "PromoFull7290-001.xml"
             assert first["save_decision"] == SaveDecision.CREATED

--- a/il_supermarket_scarper/utils/tests/test_scraper_status.py
+++ b/il_supermarket_scarper/utils/tests/test_scraper_status.py
@@ -1,0 +1,182 @@
+"""ScraperStatus verified indexes and save decisions."""
+
+import tempfile
+import unittest
+
+from il_supermarket_scarper.utils import DiskFileOutput, FileEntry, content_sha256
+from il_supermarket_scarper.utils.databases import JsonDataBase
+from il_supermarket_scarper.utils.file_output import SaveDecision
+from il_supermarket_scarper.utils.scraper_status import ScraperStatus
+from il_supermarket_scarper.utils.scraping_result import ScrapingResult
+
+
+class TestScraperStatusIndexes(unittest.IsolatedAsyncioTestCase):
+    """Hydrate once; decide from verified digests/published_at across scrapes."""
+
+    def _status(self, tmp):
+        output = DiskFileOutput(tmp)
+        db = JsonDataBase("status_idx", tmp)
+        return ScraperStatus("status_idx", status_database=db, file_output=output), db
+
+    def test_hydrate_listing_hash_skip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            status, db = self._status(tmp)
+            entry = FileEntry(name="PromoFull7290-001", url="http://x/a", size=1)
+            db.insert_document(
+                ScraperStatus.VERIFIED_DOWNLOADS,
+                {
+                    "file_name": "PromoFull7290-001.xml",
+                    "listing_hash": entry.listing_hash(),
+                    "content_sha256": "abc",
+                    "task_id": "prev",
+                },
+            )
+            status.on_scraping_start(limit=None, files_types=None)
+            self.assertTrue(
+                status._is_verified_listing(entry)  # pylint: disable=protected-access
+            )
+
+    def test_resolve_rewrote_same_across_hydrate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            status, db = self._status(tmp)
+            payload = b"<xml>same</xml>"
+            digest = content_sha256(payload)
+            db.insert_document(
+                ScraperStatus.VERIFIED_DOWNLOADS,
+                {
+                    "file_name": "PromoFull7290-001.xml",
+                    "listing_hash": "h1",
+                    "content_sha256": digest,
+                    "published_at": "2026-09-08T14:00:00",
+                    "task_id": "prev",
+                },
+            )
+            status.on_scraping_start(limit=None, files_types=None)
+            decision = status.resolve_save_decision(
+                "PromoFull7290-001.xml", digest, "2026-09-08T15:00:00"
+            )
+            self.assertEqual(decision, SaveDecision.REWROTE_SAME)
+
+    def test_resolve_stale_older_across_hydrate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            status, db = self._status(tmp)
+            db.insert_document(
+                ScraperStatus.VERIFIED_DOWNLOADS,
+                {
+                    "file_name": "PromoFull7290-001.xml",
+                    "listing_hash": "h1",
+                    "content_sha256": "olddigest",
+                    "published_at": "2026-09-08T14:00:00",
+                    "task_id": "prev",
+                },
+            )
+            status.on_scraping_start(limit=None, files_types=None)
+            decision = status.resolve_save_decision(
+                "PromoFull7290-001.xml",
+                "newdigest",
+                "2026-09-08T10:00:00",
+            )
+            self.assertEqual(decision, SaveDecision.STALE_OLDER)
+
+    def test_resolve_hash_mismatch_when_newer(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            status, db = self._status(tmp)
+            db.insert_document(
+                ScraperStatus.VERIFIED_DOWNLOADS,
+                {
+                    "file_name": "PromoFull7290-001.xml",
+                    "listing_hash": "h1",
+                    "content_sha256": "olddigest",
+                    "published_at": "2026-09-08T10:00:00",
+                    "task_id": "prev",
+                },
+            )
+            status.on_scraping_start(limit=None, files_types=None)
+            decision = status.resolve_save_decision(
+                "PromoFull7290-001.xml",
+                "newdigest",
+                "2026-09-08T14:00:00",
+            )
+            self.assertEqual(decision, SaveDecision.HASH_MISMATCH)
+
+    def test_resolve_hash_mismatch_without_dates(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            status, db = self._status(tmp)
+            db.insert_document(
+                ScraperStatus.VERIFIED_DOWNLOADS,
+                {
+                    "file_name": "PromoFull7290-001.xml",
+                    "listing_hash": "h1",
+                    "content_sha256": "olddigest",
+                    "task_id": "prev",
+                },
+            )
+            status.on_scraping_start(limit=None, files_types=None)
+            decision = status.resolve_save_decision(
+                "PromoFull7290-001.xml", "newdigest", None
+            )
+            self.assertEqual(decision, SaveDecision.HASH_MISMATCH)
+
+    async def test_decide_and_persist_skips_write_on_same_hash(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            status, _db = self._status(tmp)
+            status.on_scraping_start(limit=None, files_types=None)
+            payload = b"<xml>x</xml>"
+            digest = content_sha256(payload)
+            writes = {"n": 0}
+
+            async def persist():
+                writes["n"] += 1
+
+            first = await status.decide_and_persist(
+                "a.xml", digest, "2026-09-08T14:00:00", persist, listing_hash="lh1"
+            )
+            second = await status.decide_and_persist(
+                "a.xml", digest, "2026-09-08T15:00:00", persist, listing_hash="lh2"
+            )
+            self.assertEqual(first, SaveDecision.CREATED)
+            self.assertEqual(second, SaveDecision.REWROTE_SAME)
+            self.assertEqual(writes["n"], 1)
+
+    async def test_filter_already_downloaded_uses_set(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            status, db = self._status(tmp)
+            entry = FileEntry(name="PromoFull7290-001", url="http://x/a", size=1)
+            other = FileEntry(name="PromoFull7290-001", url="http://x/b", size=1)
+            db.insert_document(
+                ScraperStatus.VERIFIED_DOWNLOADS,
+                {
+                    "file_name": "PromoFull7290-001.xml",
+                    "listing_hash": entry.listing_hash(),
+                    "task_id": "prev",
+                },
+            )
+            status.on_scraping_start(limit=None, files_types=None)
+
+            async def listed():
+                yield entry
+                yield other
+
+            kept = []
+            async for item in status.filter_already_downloaded(listed()):
+                kept.append(item)
+            self.assertEqual(kept, [other])
+
+    def test_verified_row_uses_saved_file_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            status, db = self._status(tmp)
+            status.on_scraping_start(limit=None, files_types=None)
+            entry = FileEntry(name="PromoFull7290-001", url="http://x/a", size=1)
+            status.register_downloaded_file(
+                ScrapingResult(
+                    file_entry=entry,
+                    downloaded=True,
+                    save_decision=SaveDecision.CREATED,
+                    extract_succefully=True,
+                    content_sha256="abc",
+                    saved_file_name="PromoFull7290-001.xml",
+                )
+            )
+            docs = db.list_documents(ScraperStatus.VERIFIED_DOWNLOADS)
+            self.assertEqual(docs[-1]["file_name"], "PromoFull7290-001.xml")
+            self.assertIn(entry.listing_hash(), status._verified_listing_hashes)  # pylint: disable=protected-access

--- a/scripts/validate_downloads.py
+++ b/scripts/validate_downloads.py
@@ -66,9 +66,9 @@ class ExtractAndDropFileOutput(FileOutput):
     """Extract to prove the download, then drop bytes so a full scrape fits on disk."""
 
     def __init__(self, storage_path: str):
-        super().__init__()
         self.storage_path = storage_path
         os.makedirs(storage_path, exist_ok=True)
+        self.extract_gz = True
 
     async def save_file(
         self,
@@ -76,34 +76,23 @@ class ExtractAndDropFileOutput(FileOutput):
         file_name: str,
         file_content: bytes,
         metadata: Dict[str, Any] = None,
+        save_decision=None,
+        content_digest=None,
     ) -> Dict[str, Any]:
-        """Decompress in memory; do not persist the artifact."""
-        del file_link
-        file_content, file_name, extract_successfully, extract_error = (
-            await self._extract_if_compressed(file_content, file_name)
+        """Persist is a no-op; bytes were already extracted by the engine."""
+        del file_link, file_content
+        from il_supermarket_scarper.utils.file_output import (  # pylint: disable=import-outside-toplevel
+            SaveDecision,
         )
-        digest = None
-        save_decision = None
-        if extract_successfully:
-            published_at = (metadata or {}).get("published_at")
-            async with self._locked_save_decision(
-                file_name, file_content, published_at
-            ) as (file_name, save_decision, digest):
-                self._remember_digest(
-                    file_name, digest, published_at, save_decision
-                )
-        del file_content
+
+        decision = save_decision or SaveDecision.CREATED
         return {
             "file_name": file_name,
-            "saved": extract_successfully,
-            "extract_successfully": extract_successfully,
-            "error": (
-                None
-                if extract_successfully
-                else (extract_error or "extract failed")
-            ),
-            "content_sha256": digest,
-            "save_decision": save_decision,
+            "saved": True,
+            "extract_successfully": True,
+            "error": None,
+            "content_sha256": content_digest,
+            "save_decision": decision,
             "metadata": metadata or {},
         }
 


### PR DESCRIPTION
## Summary
- Load verified downloads once into in-memory listing-hash and per-name digest/`published_at` indexes.
- Decide overwrite/skip across scrapes without per-listing status DB scans.
- Move save decision + persist gating into `ScraperStatus`; `FileOutput` only writes/sends.

Split from #166 (PR 6/6). Stacks on the published_at PR.

## Test plan
- [ ] `python -m unittest il_supermarket_scarper.utils.tests.test_scraper_status`
- [ ] FileOutput / engine regression tests
- [ ] CI test-suite

Made with [Cursor](https://cursor.com)