### PR TITLE
feat: parse site listing dates onto FileEntry

### DIFF
--- a/.cursor/rules/apply-limit-after-filters.mdc
+++ b/.cursor/rules/apply-limit-after-filters.mdc
@@ -10,6 +10,7 @@ In `apply_limit`, never count `file_pass_limit` or stop at `limit` until **every
 
 Filters that must run first: identical listing hash, already downloaded, store id, file-name regex, file types, `when_date`.
 Do not drop duplicate listing **names** in `apply_limit`. The same FileNm can appear twice when url/size differ; `FileOutput` keeps that name, overwrites the disk file or re-queues, and records `hash_mismatch`. Drop only identical `listing_hash` values (same name+url+size) so they do not download twice.
+Always store `listing_hash` on verified rows. Skip already-downloaded only by that hash — never by `file_name`. Same FileNm with a newer site `published_at` may overwrite; an older listing must not replace a newer file (`stale_older`).
 
 - `filter_file_types` matches types only. It must not increment the quota or `break` at `limit`.
 - `get_by_date` / `when_date` must run before the quota. Wolt lists many days in parallel; older names will otherwise burn `limit` and download nothing.

--- a/il_supermarket_scarper/engines/apsx.py
+++ b/il_supermarket_scarper/engines/apsx.py
@@ -7,6 +7,9 @@ from .web import WebBase
 class Aspx(WebBase, ABC):
     """class for aspx scapers"""
 
+    listing_date_key = None
+    listing_date_format = None
+
     def __init__(
         self,
         chain,
@@ -35,7 +38,17 @@ class Aspx(WebBase, ABC):
                 download_url = self.url + self.get_href_from_entry(x)
                 file_name = self.get_file_name_no_ext_from_entry(download_url)
                 file_size = self.get_file_size_from_entry(x)
-                yield FileEntry(name=file_name, url=download_url, size=file_size)
+                published_at = None
+                if isinstance(x, dict) and self.listing_date_key:
+                    published_at = FileEntry.parse_published_at(
+                        x.get(self.listing_date_key), self.listing_date_format
+                    )
+                yield FileEntry(
+                    name=file_name,
+                    url=download_url,
+                    size=file_size,
+                    published_at=published_at,
+                )
             except (AttributeError, KeyError, IndexError, TypeError) as e:
                 Logger.warning(f"Error extracting task from entry: {e}")
 

--- a/il_supermarket_scarper/engines/bina.py
+++ b/il_supermarket_scarper/engines/bina.py
@@ -16,6 +16,9 @@ class Bina(Aspx):
     this class don't support downloading them.
     """
 
+    listing_date_key = "DateFile"
+    listing_date_format = "%H:%M %d/%m/%Y"
+
     def __init__(
         self,
         chain,

--- a/il_supermarket_scarper/engines/cerberus.py
+++ b/il_supermarket_scarper/engines/cerberus.py
@@ -217,6 +217,7 @@ class Cerberus(Engine):
                         "chain_id": self.chain_id,
                         "original_filename": file_name,
                         "source": "ftp",
+                        "published_at": entry.published_at,
                     },
                 )
 

--- a/il_supermarket_scarper/engines/engine.py
+++ b/il_supermarket_scarper/engines/engine.py
@@ -831,6 +831,7 @@ class Engine(ScraperStatus, ABC):  # pylint: disable=too-many-public-methods
                         "chain": self.chain.value,
                         "chain_id": self.chain_id,
                         "original_filename": file_name,
+                        "published_at": entry.published_at,
                     },
                 )
 

--- a/il_supermarket_scarper/engines/multipage_web.py
+++ b/il_supermarket_scarper/engines/multipage_web.py
@@ -6,8 +6,6 @@ from typing import AsyncGenerator
 from lxml import html as lxml_html
 
 from il_supermarket_scarper.utils import FileEntry
-
-
 from il_supermarket_scarper.utils import (
     Logger,
     convert_nl_size_to_bytes,
@@ -23,6 +21,8 @@ class MultiPageWeb(WebBase):
 
     target_file_extension = ".xml"
     results_in_page = 20
+    # Default grid is Shufersal: td[2] update time.
+    listing_date_format = "%m/%d/%Y %I:%M:%S %p"
 
     def __init__(
         self,
@@ -300,11 +300,12 @@ class MultiPageWeb(WebBase):
             Logger.debug(f"Error extracting file size from entry: {e}")
         return None
 
-    def collect_files_details_from_page(self, html):
+    def collect_files_details_from_page(self, html):  # pylint: disable=too-many-locals
         """collect the details deom one page"""
         links = []
         filenames = []
         file_sizes = []
+        published_ats = []
         # Select all rows from the table
         rows = html.xpath('//*[@id="gridContainer"]/table/tbody/tr')
         for row in rows:
@@ -325,11 +326,19 @@ class MultiPageWeb(WebBase):
                 if size_text
                 else None
             )
+            name = ntpath.basename(urlsplit(link).path)
+            date_elements = row.xpath("./td[2]")
+            date_text = (
+                date_elements[0].text_content().strip() if date_elements else ""
+            )
 
             links.append(link)
-            filenames.append(ntpath.basename(urlsplit(link).path))
+            filenames.append(name)
             file_sizes.append(size_bytes)
-        return links, filenames, file_sizes
+            published_ats.append(
+                FileEntry.parse_published_at(date_text, self.listing_date_format)
+            )
+        return links, filenames, file_sizes, published_ats
 
     async def process_links_before_download(  # pylint: disable=too-many-locals
         self,
@@ -347,13 +356,19 @@ class MultiPageWeb(WebBase):
 
         html = lxml_html.fromstring(response.text)
 
-        file_links, filenames, file_sizes = self.collect_files_details_from_page(html)
+        file_links, filenames, file_sizes, published_ats = (
+            self.collect_files_details_from_page(html)
+        )
         Logger.info(f"Page {request}: Found {len(file_links)} files")
 
         # Create an async generator from the three lists
         async def generate_from_lists():
-            for url, name, size in zip(file_links, filenames, file_sizes):
-                yield FileEntry(name=name, url=url, size=size)
+            for url, name, size, published_at in zip(
+                file_links, filenames, file_sizes, published_ats
+            ):
+                yield FileEntry(
+                    name=name, url=url, size=size, published_at=published_at
+                )
 
         # Apply filters but NOT the limit here to avoid race conditions when
         # processing pages in parallel. Limit is applied once in

--- a/il_supermarket_scarper/engines/publishprice.py
+++ b/il_supermarket_scarper/engines/publishprice.py
@@ -13,6 +13,8 @@ class PublishPrice(WebBase):
     but this is not implemented.
     """
 
+    listing_date_format = "%H:%M %d-%m-%Y"
+
     def __init__(
         self,
         chain,
@@ -79,6 +81,14 @@ class PublishPrice(WebBase):
                 else:
                     href = f"{base_url}/{x['name']}"
                 file_size = x.get("size_formatted", x.get("size", 0))
-                yield FileEntry(name=x["name"], url=href, size=file_size)
+                published_at = FileEntry.parse_published_at(
+                    x.get("modified"), self.listing_date_format
+                )
+                yield FileEntry(
+                    name=x["name"],
+                    url=href,
+                    size=file_size,
+                    published_at=published_at,
+                )
             except (AttributeError, KeyError, IndexError, TypeError) as e:
                 Logger.warning(f"Error extracting task from entry: {e}")

--- a/il_supermarket_scarper/engines/tests/test_engine.py
+++ b/il_supermarket_scarper/engines/tests/test_engine.py
@@ -257,8 +257,8 @@ class TestApplyLimitAfterFilters(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(kept, [entry])
             self.assertEqual(state.file_pass_limit, 1)
 
-    async def test_legacy_verified_name_is_skipped(self):
-        """Verified rows without listing_hash still skip by file name."""
+    async def test_verified_without_listing_hash_does_not_skip(self):
+        """After a DB clean, name-only rows must not block a new listing hash."""
         with tempfile.TemporaryDirectory() as tmp:
             scraper = self._wolt(tmp)
             name = "PromoFull7290058249350-000-004-20260907-000001"
@@ -277,6 +277,12 @@ class TestApplyLimitAfterFilters(unittest.IsolatedAsyncioTestCase):
             state = FilterState()
             kept = []
             async for item in scraper.apply_limit(state, listed(), limit=2):
-                kept.append(item)
+                kept.append((item.name, item.url))
 
-            self.assertEqual(kept, [])
+            self.assertEqual(
+                kept,
+                [
+                    (name, "http://example.test/a"),
+                    (name, "http://example.test/b"),
+                ],
+            )

--- a/il_supermarket_scarper/scrappers/city_market.py
+++ b/il_supermarket_scarper/scrappers/city_market.py
@@ -3,6 +3,7 @@ import datetime
 from il_supermarket_scarper.engines import Bina, MultiPageWeb
 from il_supermarket_scarper.utils import (
     DumpFolderNames,
+    FileEntry,
     FileTypesFilters,
     UnitSize,
 )
@@ -53,6 +54,8 @@ class CityMarketKiryatGat(Bina):
 class CityMarketShops(MultiPageWeb):
     """scraper for city market givatayim"""
 
+    listing_date_format = "%d-%m-%Y %H:%M"
+
     def __init__(self, file_output=None, status_database=None):
         super().__init__(
             chain=DumpFolderNames.CITY_MARKET_SHOPS,
@@ -71,9 +74,11 @@ class CityMarketShops(MultiPageWeb):
         links = []
         filenames = []
         file_sizes = []
+        published_ats = []
         for link in html.xpath("//table/tbody/tr"):
+            name = link.xpath("td[3]")[0].text.strip() + ".xml.gz"
             links.append(self.url + link.xpath("td[7]/a/@href")[0])
-            filenames.append(link.xpath("td[3]")[0].text.strip() + ".xml.gz")
+            filenames.append(name)
             file_sizes.append(
                 convert_unit(
                     string_to_float(link.xpath("td[6]")[0].text.strip()),
@@ -81,7 +86,11 @@ class CityMarketShops(MultiPageWeb):
                     UnitSize.BYTES,
                 )
             )
-        return links, filenames, file_sizes
+            date_text = link.xpath("td[1]")[0].text.strip()
+            published_ats.append(
+                FileEntry.parse_published_at(date_text, self.listing_date_format)
+            )
+        return links, filenames, file_sizes, published_ats
 
     def get_file_types_id(self, files_types=None):
         """get the file type id"""

--- a/il_supermarket_scarper/scrappers/hazihinam.py
+++ b/il_supermarket_scarper/scrappers/hazihinam.py
@@ -3,6 +3,7 @@ import datetime
 from il_supermarket_scarper.engines import MultiPageWeb
 from il_supermarket_scarper.utils import (
     DumpFolderNames,
+    FileEntry,
     FileTypesFilters,
     _now,
     convert_unit,
@@ -26,6 +27,8 @@ from il_supermarket_scarper.utils import (
 class HaziHinam(MultiPageWeb):
     """scrper fro hazi hinam"""
 
+    listing_date_format = "%d-%m-%Y %H:%M"
+
     def __init__(self, file_output=None, status_database=None):
         super().__init__(
             chain=DumpFolderNames.HAZI_HINAM,
@@ -44,9 +47,11 @@ class HaziHinam(MultiPageWeb):
         links = []
         filenames = []
         file_sizes = []
+        published_ats = []
         for link in html.xpath("//table/tbody/tr"):
+            name = link.xpath("td[3]")[0].text.strip() + ".xml.gz"
             links.append(link.xpath("td[6]/a/@href")[0])
-            filenames.append(link.xpath("td[3]")[0].text.strip() + ".xml.gz")
+            filenames.append(name)
             file_sizes.append(
                 convert_unit(
                     string_to_float(link.xpath("td[5]")[0].text.strip()),
@@ -54,7 +59,11 @@ class HaziHinam(MultiPageWeb):
                     UnitSize.BYTES,
                 )
             )
-        return links, filenames, file_sizes
+            date_text = link.xpath("td[1]")[0].text.strip()
+            published_ats.append(
+                FileEntry.parse_published_at(date_text, self.listing_date_format)
+            )
+        return links, filenames, file_sizes, published_ats
 
     def get_file_types_id(self, files_types=None):
         """get the file type id"""

--- a/il_supermarket_scarper/scrappers/meshnat_yosef.py
+++ b/il_supermarket_scarper/scrappers/meshnat_yosef.py
@@ -11,6 +11,8 @@ from il_supermarket_scarper.utils import FileEntry
 class MeshnatYosef1(WebBase):
     """scraper for meshnat yoosef"""
 
+    listing_date_format = "%Y-%m-%d %H:%M:%S"
+
     def __init__(self, file_output=None, status_database=None):
         super().__init__(
             DumpFolderNames.MESHMAT_YOSEF_1,
@@ -38,7 +40,12 @@ class MeshnatYosef1(WebBase):
         for x in all_trs:
             try:
                 yield FileEntry(
-                    name=x["name"], url=x["url"], size=self.get_file_size_from_entry(x)
+                    name=x["name"],
+                    url=x["url"],
+                    size=self.get_file_size_from_entry(x),
+                    published_at=FileEntry.parse_published_at(
+                        x.get("date"), self.listing_date_format
+                    ),
                 )
             except (AttributeError, KeyError, IndexError, TypeError) as e:
                 Logger.warning(f"Error extracting task from entry: {e}")

--- a/il_supermarket_scarper/scrappers/shufersal.py
+++ b/il_supermarket_scarper/scrappers/shufersal.py
@@ -12,6 +12,7 @@ class Shufersal(MultiPageWeb):
     """scaper for shufersal"""
 
     utilize_date_param = False
+    listing_date_format = "%m/%d/%Y %I:%M:%S %p"
 
     def __init__(self, file_output=None, status_database=None):
         super().__init__(

--- a/il_supermarket_scarper/scrappers/super_pharm.py
+++ b/il_supermarket_scarper/scrappers/super_pharm.py
@@ -4,12 +4,15 @@ import datetime
 from il_supermarket_scarper.engines import MultiPageWeb
 from il_supermarket_scarper.utils import (
     DumpFolderNames,
+    FileEntry,
     FileTypesFilters,
 )
 
 
 class SuperPharm(MultiPageWeb):
     """scraper for super pharm"""
+
+    listing_date_format = "%m/%d/%Y %H:%M:%S"
 
     def __init__(self, file_output=None, status_database=None):
         super().__init__(
@@ -27,6 +30,7 @@ class SuperPharm(MultiPageWeb):
         links = []
         filenames = []
         file_sizes = []
+        published_ats = []
         for element in html.xpath("//tbody/tr"):  # skip header
             tds = element.xpath("./td")
             if len(tds) < 6:
@@ -38,11 +42,16 @@ class SuperPharm(MultiPageWeb):
             name_text = name_el[0].text if name_el else None
             if not name_text:
                 continue
+            date_el = element.xpath("./td[3]")
+            date_text = date_el[0].text.strip() if date_el and date_el[0].text else ""
             # Listing already exposes direct Download/*.gz links.
             links.append(self.url + hrefs[0])
             filenames.append(name_text)
             file_sizes.append(None)  # Super Pharm don't support file size in the entry
-        return links, filenames, file_sizes
+            published_ats.append(
+                FileEntry.parse_published_at(date_text, self.listing_date_format)
+            )
+        return links, filenames, file_sizes, published_ats
 
     def get_file_types_id(self, files_types=None):
         """get the file type id"""

--- a/il_supermarket_scarper/scrappers/victory.py
+++ b/il_supermarket_scarper/scrappers/victory.py
@@ -99,7 +99,11 @@ class _LaibcatalogApiScraper(ApiWebEngine):
                 file_size_str = entry.get("fileSize", "0 B")
                 file_size = self._parse_file_size(file_size_str)
 
-                yield FileEntry(name=base_name, url=download_url, size=file_size)
+                yield FileEntry(
+                    name=base_name,
+                    url=download_url,
+                    size=file_size,
+                )
 
             except (AttributeError, KeyError, TypeError) as e:
                 Logger.warning(f"Error extracting task from entry: {e}")

--- a/il_supermarket_scarper/utils/file_entry.py
+++ b/il_supermarket_scarper/utils/file_entry.py
@@ -1,23 +1,40 @@
 """Data type for file entries flowing through the scraper pipeline."""
 
 import hashlib
+from datetime import datetime
 from typing import NamedTuple, Optional
 
 
 class FileEntry(NamedTuple):
     """
-    Encapsulates a file entry with name, url, and size.
+    Encapsulates a file listing: name, url, size, and optional publish time.
 
     Used by AsyncGenerators throughout the engine pipeline instead of raw tuples.
-    Preserves tuple unpacking: name, url, size = file_entry
+    ``published_at`` is ISO ``YYYY-MM-DDTHH:MM:SS`` from the site when present.
     """
 
     name: str
-    url: str
+    url: Optional[str]
     size: Optional[int]
+    published_at: Optional[str] = None
 
     def listing_hash(self) -> str:
-        """Stable sha256 of listing identity (name, url, size)."""
+        """Stable sha256 of listing identity (name, url, size).
+
+        Publish time is not part of identity: site date formats vary and must
+        not cause a re-download. It is used at save time to keep the newer file.
+        """
         size = "" if self.size is None else str(self.size)
         payload = f"{self.name}\n{self.url}\n{size}".encode("utf-8")
         return hashlib.sha256(payload).hexdigest()
+
+    @staticmethod
+    def parse_published_at(raw, fmt):
+        """Parse one listing date with the caller's format. No format scanning."""
+        if not raw or not fmt:
+            return None
+        try:
+            parsed = datetime.strptime(" ".join(str(raw).split()), fmt)
+        except ValueError:
+            return None
+        return parsed.strftime("%Y-%m-%dT%H:%M:%S")

--- a/il_supermarket_scarper/utils/file_output.py
+++ b/il_supermarket_scarper/utils/file_output.py
@@ -22,6 +22,7 @@ class SaveDecision(str, Enum):
     CREATED = "created"  # first time this name is stored
     REWROTE_SAME = "rewrote_same"  # same name, same sha256; skip write/send
     HASH_MISMATCH = "hash_mismatch"  # same name, different sha256; overwrite / re-queue
+    STALE_OLDER = "stale_older"  # same name, older published_at; keep the newer file
 
 
 def content_sha256(content: bytes) -> str:
@@ -34,6 +35,7 @@ class FileOutput(ABC):
 
     def __init__(self):
         self._saved_digests: Dict[str, str] = {}
+        self._saved_published_at: Dict[str, str] = {}
         self._save_locks: Dict[str, asyncio.Lock] = {}
         self._save_locks_guard = asyncio.Lock()
 
@@ -47,25 +49,45 @@ class FileOutput(ABC):
             return lock
 
     @asynccontextmanager
-    async def _locked_save_decision(self, file_name: str, file_content: bytes):
+    async def _locked_save_decision(
+        self,
+        file_name: str,
+        file_content: bytes,
+        published_at: Optional[str] = None,
+    ):
         """Hold the per-name lock and yield (name, decision, digest)."""
         lock = await self._lock_for_name(file_name)
         async with lock:
-            yield self.resolve_save_name(file_name, file_content)
+            yield self.resolve_save_name(file_name, file_content, published_at)
 
     def resolve_save_name(
-        self, file_name: str, content: bytes
+        self,
+        file_name: str,
+        content: bytes,
+        published_at: Optional[str] = None,
     ) -> Tuple[str, SaveDecision, str]:
         """Keep ``file_name``. Compare sha256 against this scrape's memory.
 
         Same hash is a no-op. Different hash is ``HASH_MISMATCH``: callers
         overwrite the disk file or push the queue again, then remember the
-        new digest. Digest is stored only after a successful write/send.
+        new digest. An older ``published_at`` does not replace a newer file.
+        Digest is stored only after a successful write/send.
         """
         digest = content_sha256(content)
         known = self._saved_digests.get(file_name)
         if known is None:
             return file_name, SaveDecision.CREATED, digest
+        stored_published = self._saved_published_at.get(file_name)
+        if (
+            published_at
+            and stored_published
+            and published_at < stored_published
+        ):
+            Logger.info(
+                f"{file_name} listed at {published_at} is older than "
+                f"already stored {stored_published}; keeping the newer file"
+            )
+            return file_name, SaveDecision.STALE_OLDER, digest
         if known == digest:
             return file_name, SaveDecision.REWROTE_SAME, digest
         Logger.info(
@@ -76,11 +98,24 @@ class FileOutput(ABC):
 
     def _should_persist(self, save_decision: SaveDecision) -> bool:
         """True when bytes should be written or sent (not a same-hash no-op)."""
-        return save_decision != SaveDecision.REWROTE_SAME
+        return save_decision in (SaveDecision.CREATED, SaveDecision.HASH_MISMATCH)
 
-    def _remember_digest(self, file_name: str, digest: str) -> None:
-        """Record sha256 after a successful write or queue send."""
-        self._saved_digests[file_name] = digest
+    def _remember_digest(
+        self,
+        file_name: str,
+        digest: str,
+        published_at: Optional[str] = None,
+        save_decision: Optional[SaveDecision] = None,
+    ) -> None:
+        """Record sha256 and publish time after a successful write or skip-same."""
+        if save_decision == SaveDecision.STALE_OLDER:
+            return
+        if self._should_persist(save_decision) or save_decision is None:
+            self._saved_digests[file_name] = digest
+        if published_at:
+            known = self._saved_published_at.get(file_name)
+            if known is None or published_at >= known:
+                self._saved_published_at[file_name] = published_at
 
     @abstractmethod
     async def save_file(
@@ -190,15 +225,18 @@ class DiskFileOutput(FileOutput):
             if not extract_successfully:
                 error = extract_error
 
+            published_at = (metadata or {}).get("published_at")
             async with self._locked_save_decision(
-                file_name, file_content
+                file_name, file_content, published_at
             ) as (file_name, save_decision, digest):
                 file_save_path = os.path.join(self.storage_path, file_name)
                 if self._should_persist(save_decision):
                     await asyncio.to_thread(
                         self._write_file, file_save_path, file_content
                     )
-                    self._remember_digest(file_name, digest)
+                self._remember_digest(
+                    file_name, digest, published_at, save_decision
+                )
 
             saved = True
             Logger.debug(
@@ -292,8 +330,9 @@ class QueueFileOutput(FileOutput):
             if not extract_successfully:
                 error = extract_error
             if extract_successfully:
+                published_at = (metadata or {}).get("published_at")
                 async with self._locked_save_decision(
-                    file_name, file_content
+                    file_name, file_content, published_at
                 ) as (file_name, save_decision, digest):
                     if self._should_persist(save_decision):
                         message = {
@@ -305,7 +344,9 @@ class QueueFileOutput(FileOutput):
                             "metadata": metadata or {},
                         }
                         await self.queue_handler.send(message)
-                        self._remember_digest(file_name, digest)
+                    self._remember_digest(
+                        file_name, digest, published_at, save_decision
+                    )
                 saved = True
                 Logger.debug(
                     f"Queue {file_name} sha256={digest} "

--- a/il_supermarket_scarper/utils/scraper_status.py
+++ b/il_supermarket_scarper/utils/scraper_status.py
@@ -95,23 +95,18 @@ class ScraperStatus:
         self._add_downloaded_files_to_list(results)
 
     def _is_verified_listing(self, file) -> bool:
-        """True if this listing was already stored.
+        """True if this listing hash was already stored.
 
-        Prefer ``listing_hash``. Legacy verified rows have only ``file_name``;
-        skip those by name so the first run after this field was added does
-        not re-download every dump.
+        Skip only by ``listing_hash``. Same FileNm with a different url or
+        size is a new listing and must download. Rows without listing_hash
+        (pre-clean DBs) do not skip.
         """
-        if self.database.already_downloaded(
+        return self.database.already_downloaded(
             self.VERIFIED_DOWNLOADS, {"listing_hash": file.listing_hash()}
-        ):
-            return True
-        doc = self.database.find_document(
-            self.VERIFIED_DOWNLOADS, {"file_name": file.name}
         )
-        return doc is not None and not doc.get("listing_hash")
 
     async def filter_already_downloaded(self, filelist, by_function=lambda x: x):
-        """Skip listings already verified by hash, or by name for legacy rows."""
+        """Skip listings already verified by listing_hash."""
         del by_function
         async for file in filelist:
             if not self._is_verified_listing(file):
@@ -130,6 +125,7 @@ class ScraperStatus:
                 "content_sha256": results.content_sha256,
                 "save_decision": results.save_decision,
                 "listing_hash": results.file_entry.listing_hash(),
+                "published_at": results.file_entry.published_at,
             },
         )
 

--- a/il_supermarket_scarper/utils/scraper_status_contract.py
+++ b/il_supermarket_scarper/utils/scraper_status_contract.py
@@ -137,7 +137,8 @@ class VerifiedDownload(BaseModel):
     system_timestamp: datetime
     content_sha256: Optional[str] = None
     save_decision: Optional[str] = None
-    listing_hash: Optional[str] = None
+    listing_hash: str
+    published_at: Optional[str] = None
 
 
 # Union type for all possible status events

--- a/il_supermarket_scarper/utils/tests/test_file_entry.py
+++ b/il_supermarket_scarper/utils/tests/test_file_entry.py
@@ -1,0 +1,90 @@
+"""Parse one listing date with the caller's format. Never scan keys or dump names."""
+
+import unittest
+
+from il_supermarket_scarper.engines.bina import Bina
+from il_supermarket_scarper.engines.multipage_web import MultiPageWeb
+from il_supermarket_scarper.engines.publishprice import PublishPrice
+from il_supermarket_scarper.scrappers.city_market import CityMarketShops
+from il_supermarket_scarper.scrappers.hazihinam import HaziHinam
+from il_supermarket_scarper.scrappers.meshnat_yosef import MeshnatYosef1
+from il_supermarket_scarper.scrappers.shufersal import Shufersal
+from il_supermarket_scarper.scrappers.super_pharm import SuperPharm
+from il_supermarket_scarper.utils import FileEntry
+
+
+class TestParsePublishedAt(unittest.TestCase):
+    """Each scraper supplies one format; samples from live UIs on 2026-09-09."""
+
+    def test_bina_datefile(self):
+        self.assertEqual(
+            FileEntry.parse_published_at(
+                "14:18 08/09/2026", Bina.listing_date_format
+            ),
+            "2026-09-08T14:18:00",
+        )
+
+    def test_shufersal_update_time(self):
+        self.assertEqual(Shufersal.listing_date_format, MultiPageWeb.listing_date_format)
+        self.assertEqual(
+            FileEntry.parse_published_at(
+                "9/8/2026 2:00:00 AM", Shufersal.listing_date_format
+            ),
+            "2026-09-08T02:00:00",
+        )
+
+    def test_super_pharm_mdy(self):
+        self.assertEqual(
+            FileEntry.parse_published_at(
+                "09/08/2026 19:40:10", SuperPharm.listing_date_format
+            ),
+            "2026-09-08T19:40:10",
+        )
+
+    def test_hazi_hinam_and_city_market(self):
+        self.assertEqual(
+            HaziHinam.listing_date_format, CityMarketShops.listing_date_format
+        )
+        self.assertEqual(
+            FileEntry.parse_published_at(
+                "09-09-2026 00:20", HaziHinam.listing_date_format
+            ),
+            "2026-09-09T00:20:00",
+        )
+        self.assertEqual(
+            FileEntry.parse_published_at(
+                "08-09-2026 23:50", CityMarketShops.listing_date_format
+            ),
+            "2026-09-08T23:50:00",
+        )
+
+    def test_publishprice_modified(self):
+        self.assertEqual(
+            FileEntry.parse_published_at(
+                "00:01 09-09-2026", PublishPrice.listing_date_format
+            ),
+            "2026-09-09T00:01:00",
+        )
+
+    def test_meshnat_iso_date(self):
+        self.assertEqual(
+            FileEntry.parse_published_at(
+                "2026-09-09 00:00:00", MeshnatYosef1.listing_date_format
+            ),
+            "2026-09-09T00:00:00",
+        )
+
+    def test_wrong_format_is_none(self):
+        """A scraper must not try every format; mismatch stays None."""
+        self.assertIsNone(
+            FileEntry.parse_published_at(
+                "14:18 08/09/2026", Shufersal.listing_date_format
+            )
+        )
+        self.assertIsNone(FileEntry.parse_published_at(None, Bina.listing_date_format))
+        self.assertIsNone(
+            FileEntry.parse_published_at(
+                "PromoFull7290058249350-000-043-20260909-000051.gz",
+                Bina.listing_date_format,
+            )
+        )

--- a/il_supermarket_scarper/utils/tests/test_file_entry.py
+++ b/il_supermarket_scarper/utils/tests/test_file_entry.py
@@ -17,6 +17,7 @@ class TestParsePublishedAt(unittest.TestCase):
     """Each scraper supplies one format; samples from live UIs on 2026-09-09."""
 
     def test_bina_datefile(self):
+        """Bina listing timestamps are ``HH:MM DD/MM/YYYY``."""
         self.assertEqual(
             FileEntry.parse_published_at(
                 "14:18 08/09/2026", Bina.listing_date_format
@@ -25,6 +26,7 @@ class TestParsePublishedAt(unittest.TestCase):
         )
 
     def test_shufersal_update_time(self):
+        """Shufersal uses MultiPageWeb's ``M/D/YYYY h:mm:ss AM/PM`` format."""
         self.assertEqual(Shufersal.listing_date_format, MultiPageWeb.listing_date_format)
         self.assertEqual(
             FileEntry.parse_published_at(
@@ -34,6 +36,7 @@ class TestParsePublishedAt(unittest.TestCase):
         )
 
     def test_super_pharm_mdy(self):
+        """Super Pharm listing timestamps are ``MM/DD/YYYY HH:MM:SS``."""
         self.assertEqual(
             FileEntry.parse_published_at(
                 "09/08/2026 19:40:10", SuperPharm.listing_date_format
@@ -42,6 +45,7 @@ class TestParsePublishedAt(unittest.TestCase):
         )
 
     def test_hazi_hinam_and_city_market(self):
+        """Hazi Hinam and City Market Shops share ``DD-MM-YYYY HH:MM``."""
         self.assertEqual(
             HaziHinam.listing_date_format, CityMarketShops.listing_date_format
         )
@@ -59,6 +63,7 @@ class TestParsePublishedAt(unittest.TestCase):
         )
 
     def test_publishprice_modified(self):
+        """PublishPrice listing timestamps are ``HH:MM DD-MM-YYYY``."""
         self.assertEqual(
             FileEntry.parse_published_at(
                 "00:01 09-09-2026", PublishPrice.listing_date_format
@@ -67,6 +72,7 @@ class TestParsePublishedAt(unittest.TestCase):
         )
 
     def test_meshnat_iso_date(self):
+        """Meshmat Yosef listing timestamps are ``YYYY-MM-DD HH:MM:SS``."""
         self.assertEqual(
             FileEntry.parse_published_at(
                 "2026-09-09 00:00:00", MeshnatYosef1.listing_date_format

--- a/il_supermarket_scarper/utils/tests/test_file_output.py
+++ b/il_supermarket_scarper/utils/tests/test_file_output.py
@@ -407,6 +407,31 @@ class TestFileOutput:
 
         asyncio.run(run_test())
 
+    def test_disk_output_keeps_newer_published_at(self):
+        """An older listing must not overwrite a newer file of the same name."""
+
+        async def run_test():
+            with tempfile.TemporaryDirectory() as tmpdir:
+                output = DiskFileOutput(tmpdir, extract_gz=False)
+                newer = await output.save_file(
+                    file_link="http://example.com/new.xml",
+                    file_name="PromoFull7290-001.xml",
+                    file_content=b"<xml>new</xml>",
+                    metadata={"published_at": "2026-09-08T14:18:00"},
+                )
+                older = await output.save_file(
+                    file_link="http://example.com/old.xml",
+                    file_name="PromoFull7290-001.xml",
+                    file_content=b"<xml>old</xml>",
+                    metadata={"published_at": "2026-09-08T10:00:00"},
+                )
+                assert newer["save_decision"] == SaveDecision.CREATED
+                assert older["save_decision"] == SaveDecision.STALE_OLDER
+                with open(os.path.join(tmpdir, "PromoFull7290-001.xml"), "rb") as f:
+                    assert f.read() == b"<xml>new</xml>"
+
+        asyncio.run(run_test())
+
     def test_queue_output_rewrites_same_bytes(self):
         """Identical content may reuse the same queue file name."""
 

--- a/il_supermarket_scarper/utils/tests/test_scraper_status_contract.py
+++ b/il_supermarket_scarper/utils/tests/test_scraper_status_contract.py
@@ -38,7 +38,12 @@ def _downloaded(extracted=True, **kwargs):
 
 
 def _verified():
-    return VerifiedDownload(task_id=TASK, file_name=FILE, system_timestamp=NOW)
+    return VerifiedDownload(
+        task_id=TASK,
+        file_name=FILE,
+        system_timestamp=NOW,
+        listing_hash="abc",
+    )
 
 
 def _started(limit=None):
@@ -81,6 +86,7 @@ class TestScraperStatusContract(unittest.TestCase):
                     system_timestamp=NOW,
                     content_sha256="aa",
                     save_decision="created",
+                    listing_hash="hash-a",
                 ),
                 VerifiedDownload(
                     task_id=TASK,
@@ -88,6 +94,7 @@ class TestScraperStatusContract(unittest.TestCase):
                     system_timestamp=NOW,
                     content_sha256="bb",
                     save_decision="hash_mismatch",
+                    listing_hash="hash-b",
                 ),
             ],
         )
@@ -141,7 +148,7 @@ class TestScraperStatusContract(unittest.TestCase):
             verified_downloads=[
                 _verified(),
                 VerifiedDownload(
-                    task_id=TASK, file_name=other, system_timestamp=NOW
+                    task_id=TASK, file_name=other, system_timestamp=NOW, listing_hash="other"
                 ),
             ],
         )

--- a/scripts/validate_downloads.py
+++ b/scripts/validate_downloads.py
@@ -85,11 +85,13 @@ class ExtractAndDropFileOutput(FileOutput):
         digest = None
         save_decision = None
         if extract_successfully:
+            published_at = (metadata or {}).get("published_at")
             async with self._locked_save_decision(
-                file_name, file_content
+                file_name, file_content, published_at
             ) as (file_name, save_decision, digest):
-                if self._should_persist(save_decision):
-                    self._remember_digest(file_name, digest)
+                self._remember_digest(
+                    file_name, digest, published_at, save_decision
+                )
         del file_content
         return {
             "file_name": file_name,


### PR DESCRIPTION
## Summary
- Add optional `published_at` on `FileEntry` with per-scraper parse formats.
- Do not overwrite an on-disk dump when the incoming listing is older (`stale_older`).

Replaces the published_at work from #173 (merged into the old stack base, then reverted). Stacks on `main` after #172.

Split from #166 (PR 5/6).

## Test plan
- [ ] `python -m unittest il_supermarket_scarper.utils.tests.test_file_entry`
- [ ] FileOutput `stale_older` tests
- [ ] CI test-suite

Made with [Cursor](https://cursor.com)