### PR TITLE
perf: hydrate verified indexes once for Json status lookups

### DIFF
--- a/il_supermarket_scarper/utils/databases/base.py
+++ b/il_supermarket_scarper/utils/databases/base.py
@@ -23,6 +23,10 @@ class AbstractDataBase(ABC):
         """Return the first matching document, or None."""
         return None
 
+    def list_documents(self, collection_name):  # pylint: disable=unused-argument
+        """Return all documents in a collection (empty list if missing)."""
+        return []
+
     @abstractmethod
     def get_last_modified(self):
         """Get the last modified timestamp when scraper last wrote to this database."""

--- a/il_supermarket_scarper/utils/databases/json_file.py
+++ b/il_supermarket_scarper/utils/databases/json_file.py
@@ -93,20 +93,26 @@ class JsonDataBase(AbstractDataBase):
 
     def find_document(self, collection_name, query):
         """Return the first matching document, or None."""
-        file_path = self._get_database_file_path()
-
-        if os.path.exists(file_path):
-            with open(file_path, "r", encoding="utf-8") as file:
-                try:
-                    data = json.load(file)
-
-                    if collection_name in data:
-                        for document in data[collection_name]:
-                            if all(item in document.items() for item in query.items()):
-                                return document
-                except json.JSONDecodeError:
-                    Logger.warning(f"File {file_path} is corrupted.")
+        for document in self.list_documents(collection_name):
+            if all(item in document.items() for item in query.items()):
+                return document
         return None
+
+    def list_documents(self, collection_name):
+        """Return all documents in a collection (empty list if missing)."""
+        file_path = self._get_database_file_path()
+        if not os.path.exists(file_path):
+            return []
+        with open(file_path, "r", encoding="utf-8") as file:
+            try:
+                data = json.load(file)
+            except json.JSONDecodeError:
+                Logger.warning(f"File {file_path} is corrupted.")
+                return []
+        docs = data.get(collection_name, [])
+        if not isinstance(docs, list):
+            return []
+        return docs
 
     def _update_last_modified(self):
         """Update the last modified timestamp to current time."""

--- a/il_supermarket_scarper/utils/databases/mongo.py
+++ b/il_supermarket_scarper/utils/databases/mongo.py
@@ -44,6 +44,12 @@ class MongoDataBase(AbstractDataBase):
             self.create_connection()
         return self.store_db[collection_name].find_one(query)
 
+    def list_documents(self, collection_name):
+        """Return all documents in a collection (empty list if missing)."""
+        if self.store_db is None:
+            self.create_connection()
+        return list(self.store_db[collection_name].find({}))
+
     def _update_last_modified(self):
         """Update the last modified timestamp to current time."""
         if self.store_db is None:

--- a/il_supermarket_scarper/utils/scraper_status.py
+++ b/il_supermarket_scarper/utils/scraper_status.py
@@ -45,9 +45,7 @@ class ScraperStatus:
     def on_scraping_start(self, limit, files_types, **additional_info):
         """Report that scraping has started."""
         self.task_id = str(uuid.uuid4())
-        # Same-scrape indexes only; cross-scrape listing skip still hits the DB.
-        self._verified_listing_hashes = set()
-        self._saved_by_name = {}
+        self._hydrate_verified_indexes()
 
         self._insert_global_status(
             ScraperStatus.STARTED,
@@ -55,6 +53,36 @@ class ScraperStatus:
             files_requested=files_types,
             **additional_info,
         )
+
+    def _hydrate_verified_indexes(self) -> None:
+        """Load verified_downloads once into O(1) listing/hash indexes."""
+        self._verified_listing_hashes = set()
+        self._saved_by_name = {}
+        for doc in self.database.list_documents(self.VERIFIED_DOWNLOADS):
+            listing_hash = doc.get("listing_hash")
+            if listing_hash:
+                self._verified_listing_hashes.add(listing_hash)
+            file_name = doc.get("file_name")
+            if not file_name:
+                continue
+            digest = doc.get("content_sha256")
+            published_at = doc.get("published_at")
+            known = self._saved_by_name.get(file_name)
+            if known is None:
+                self._saved_by_name[file_name] = {
+                    "content_sha256": digest,
+                    "published_at": published_at,
+                }
+                continue
+            stored_published = known.get("published_at")
+            if published_at and (
+                stored_published is None or published_at >= stored_published
+            ):
+                known["published_at"] = published_at
+                if digest:
+                    known["content_sha256"] = digest
+            elif known.get("content_sha256") is None and digest:
+                known["content_sha256"] = digest
 
     def register_saw_file(
         self,
@@ -108,15 +136,9 @@ class ScraperStatus:
 
         Skip only by ``listing_hash``. Same FileNm with a different url or
         size is a new listing and must download. Rows without listing_hash
-        (pre-clean DBs) do not skip. Same-scrape hits the in-memory set;
-        otherwise query the status DB.
+        (pre-clean DBs) do not skip.
         """
-        listing_hash = file.listing_hash()
-        if listing_hash in self._verified_listing_hashes:
-            return True
-        return self.database.already_downloaded(
-            self.VERIFIED_DOWNLOADS, {"listing_hash": listing_hash}
-        )
+        return file.listing_hash() in self._verified_listing_hashes
 
     async def filter_already_downloaded(self, filelist, by_function=lambda x: x):
         """Skip listings already verified by listing_hash."""

--- a/il_supermarket_scarper/utils/tests/test_scraper_status.py
+++ b/il_supermarket_scarper/utils/tests/test_scraper_status.py
@@ -1,4 +1,4 @@
-"""ScraperStatus save-decision extraction (same-scrape indexes)."""
+"""ScraperStatus verified indexes and save decisions."""
 
 import tempfile
 import unittest
@@ -10,50 +10,67 @@ from il_supermarket_scarper.utils.scraper_status import ScraperStatus
 from il_supermarket_scarper.utils.scraping_result import ScrapingResult
 
 
-class TestScraperStatusSaveDecision(unittest.IsolatedAsyncioTestCase):
-    """Decide/persist lives on ScraperStatus; indexes start empty each scrape."""
+class TestScraperStatusIndexes(unittest.IsolatedAsyncioTestCase):
+    """Hydrate once; decide from verified digests/published_at across scrapes."""
 
     def _status(self, tmp):
         output = DiskFileOutput(tmp)
         db = JsonDataBase("status_idx", tmp)
         return ScraperStatus("status_idx", status_database=db, file_output=output), db
 
-    def test_resolve_created_when_unknown(self):
+    def test_hydrate_listing_hash_skip(self):
         with tempfile.TemporaryDirectory() as tmp:
-            status, _db = self._status(tmp)
-            status.on_scraping_start(limit=None, files_types=None)
-            decision = status.resolve_save_decision(
-                "PromoFull7290-001.xml", "digest", None
+            status, db = self._status(tmp)
+            entry = FileEntry(name="PromoFull7290-001", url="http://x/a", size=1)
+            db.insert_document(
+                ScraperStatus.VERIFIED_DOWNLOADS,
+                {
+                    "file_name": "PromoFull7290-001.xml",
+                    "listing_hash": entry.listing_hash(),
+                    "content_sha256": "abc",
+                    "task_id": "prev",
+                },
             )
-            self.assertEqual(decision, SaveDecision.CREATED)
+            status.on_scraping_start(limit=None, files_types=None)
+            self.assertTrue(
+                status._is_verified_listing(entry)  # pylint: disable=protected-access
+            )
 
-    def test_resolve_rewrote_same_within_scrape(self):
+    def test_resolve_rewrote_same_across_hydrate(self):
         with tempfile.TemporaryDirectory() as tmp:
-            status, _db = self._status(tmp)
-            status.on_scraping_start(limit=None, files_types=None)
-            digest = content_sha256(b"<xml>same</xml>")
-            status._remember_save(  # pylint: disable=protected-access
-                "PromoFull7290-001.xml",
-                digest,
-                "2026-09-08T14:00:00",
-                SaveDecision.CREATED,
-                listing_hash="h1",
+            status, db = self._status(tmp)
+            payload = b"<xml>same</xml>"
+            digest = content_sha256(payload)
+            db.insert_document(
+                ScraperStatus.VERIFIED_DOWNLOADS,
+                {
+                    "file_name": "PromoFull7290-001.xml",
+                    "listing_hash": "h1",
+                    "content_sha256": digest,
+                    "published_at": "2026-09-08T14:00:00",
+                    "task_id": "prev",
+                },
             )
+            status.on_scraping_start(limit=None, files_types=None)
             decision = status.resolve_save_decision(
                 "PromoFull7290-001.xml", digest, "2026-09-08T15:00:00"
             )
             self.assertEqual(decision, SaveDecision.REWROTE_SAME)
 
-    def test_resolve_stale_older_within_scrape(self):
+    def test_resolve_stale_older_across_hydrate(self):
         with tempfile.TemporaryDirectory() as tmp:
-            status, _db = self._status(tmp)
-            status.on_scraping_start(limit=None, files_types=None)
-            status._remember_save(  # pylint: disable=protected-access
-                "PromoFull7290-001.xml",
-                "olddigest",
-                "2026-09-08T14:00:00",
-                SaveDecision.CREATED,
+            status, db = self._status(tmp)
+            db.insert_document(
+                ScraperStatus.VERIFIED_DOWNLOADS,
+                {
+                    "file_name": "PromoFull7290-001.xml",
+                    "listing_hash": "h1",
+                    "content_sha256": "olddigest",
+                    "published_at": "2026-09-08T14:00:00",
+                    "task_id": "prev",
+                },
             )
+            status.on_scraping_start(limit=None, files_types=None)
             decision = status.resolve_save_decision(
                 "PromoFull7290-001.xml",
                 "newdigest",
@@ -63,14 +80,18 @@ class TestScraperStatusSaveDecision(unittest.IsolatedAsyncioTestCase):
 
     def test_resolve_hash_mismatch_when_newer(self):
         with tempfile.TemporaryDirectory() as tmp:
-            status, _db = self._status(tmp)
-            status.on_scraping_start(limit=None, files_types=None)
-            status._remember_save(  # pylint: disable=protected-access
-                "PromoFull7290-001.xml",
-                "olddigest",
-                "2026-09-08T10:00:00",
-                SaveDecision.CREATED,
+            status, db = self._status(tmp)
+            db.insert_document(
+                ScraperStatus.VERIFIED_DOWNLOADS,
+                {
+                    "file_name": "PromoFull7290-001.xml",
+                    "listing_hash": "h1",
+                    "content_sha256": "olddigest",
+                    "published_at": "2026-09-08T10:00:00",
+                    "task_id": "prev",
+                },
             )
+            status.on_scraping_start(limit=None, files_types=None)
             decision = status.resolve_save_decision(
                 "PromoFull7290-001.xml",
                 "newdigest",
@@ -80,14 +101,17 @@ class TestScraperStatusSaveDecision(unittest.IsolatedAsyncioTestCase):
 
     def test_resolve_hash_mismatch_without_dates(self):
         with tempfile.TemporaryDirectory() as tmp:
-            status, _db = self._status(tmp)
-            status.on_scraping_start(limit=None, files_types=None)
-            status._remember_save(  # pylint: disable=protected-access
-                "PromoFull7290-001.xml",
-                "olddigest",
-                None,
-                SaveDecision.CREATED,
+            status, db = self._status(tmp)
+            db.insert_document(
+                ScraperStatus.VERIFIED_DOWNLOADS,
+                {
+                    "file_name": "PromoFull7290-001.xml",
+                    "listing_hash": "h1",
+                    "content_sha256": "olddigest",
+                    "task_id": "prev",
+                },
             )
+            status.on_scraping_start(limit=None, files_types=None)
             decision = status.resolve_save_decision(
                 "PromoFull7290-001.xml", "newdigest", None
             )
@@ -114,7 +138,7 @@ class TestScraperStatusSaveDecision(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(second, SaveDecision.REWROTE_SAME)
             self.assertEqual(writes["n"], 1)
 
-    async def test_filter_already_downloaded_uses_db(self):
+    async def test_filter_already_downloaded_uses_set(self):
         with tempfile.TemporaryDirectory() as tmp:
             status, db = self._status(tmp)
             entry = FileEntry(name="PromoFull7290-001", url="http://x/a", size=1)
@@ -153,13 +177,6 @@ class TestScraperStatusSaveDecision(unittest.IsolatedAsyncioTestCase):
                     saved_file_name="PromoFull7290-001.xml",
                 )
             )
-            doc = db.find_document(
-                ScraperStatus.VERIFIED_DOWNLOADS,
-                {"file_name": "PromoFull7290-001.xml"},
-            )
-            self.assertIsNotNone(doc)
-            self.assertEqual(doc["listing_hash"], entry.listing_hash())
-            self.assertIn(
-                entry.listing_hash(),
-                status._verified_listing_hashes,  # pylint: disable=protected-access
-            )
+            docs = db.list_documents(ScraperStatus.VERIFIED_DOWNLOADS)
+            self.assertEqual(docs[-1]["file_name"], "PromoFull7290-001.xml")
+            self.assertIn(entry.listing_hash(), status._verified_listing_hashes)  # pylint: disable=protected-access


### PR DESCRIPTION
## Summary
- Add `list_documents` on status DB backends.
- Hydrate listing-hash and per-name digest/\`published_at\` indexes once at scrape start.
- Skip already-downloaded and resolve save decisions in O(1) without per-listing Json scans.

Re-lands #178 onto \`main\`. #178 was merged into \`split/extract-save-decision\` (its stack base) after #177 had already merged to \`main\`, so the hydrate commit never reached \`main\`.

## Test plan
- [ ] \`python -m unittest il_supermarket_scarper.utils.tests.test_scraper_status\`
- [ ] CI test-suite

Made with [Cursor](https://cursor.com)